### PR TITLE
fix(vbtc-v2): never silently skip the withdrawal completion TX

### DIFF
--- a/lib/core/storage.dart
+++ b/lib/core/storage.dart
@@ -37,6 +37,8 @@ abstract class Storage {
   static const WEB_PRIMARY_ADDRESS = "WEB_PRIMARY_ADDRESS";
   static const PENDING_REDIRECT_URL = "PENDING_REDIRECT_URL";
   static const BUTTERFLY_LINKS = "BUTTERFLY_LINKS";
+  static const PENDING_VBTC_WITHDRAWAL_COMPLETIONS =
+      "PENDING_VBTC_WITHDRAWAL_COMPLETIONS";
   bool isInitialized = false;
 
   Future<void> init();

--- a/lib/features/btc/components/withdrawal_processing_dialog.dart
+++ b/lib/features/btc/components/withdrawal_processing_dialog.dart
@@ -57,7 +57,7 @@ class WithdrawalProcessingDialog extends StatefulWidget {
   State<WithdrawalProcessingDialog> createState() => _WithdrawalProcessingDialogState();
 }
 
-enum _DialogState { waitingForBlock, processing, success, failure }
+enum _DialogState { waitingForBlock, processing, verifying, success, failure }
 
 class _WithdrawalProcessingDialogState extends State<WithdrawalProcessingDialog> {
   _DialogState _state = _DialogState.processing;
@@ -66,6 +66,10 @@ class _WithdrawalProcessingDialogState extends State<WithdrawalProcessingDialog>
   int _confirmationPollCount = 0;
   static const _maxConfirmationPolls = 60; // 60 * 5s = 5 minutes max
   static const _confirmationPollInterval = Duration(seconds: 5);
+  static const _maxVerificationPolls = 24; // 24 * 5s = 2 minutes max
+
+  /// Guards Retry against a double tap starting two signing ceremonies.
+  bool _busy = false;
 
   @override
   void initState() {
@@ -125,6 +129,8 @@ class _WithdrawalProcessingDialogState extends State<WithdrawalProcessingDialog>
   }
 
   Future<void> _runCompleteWithdrawal() async {
+    if (_busy) return;
+    _busy = true;
     debugPrint('$_tag Calling completeWithdrawal — scUid: ${widget.scUid}, requestHash: ${widget.requestHash}');
     setState(() => _state = _DialogState.processing);
 
@@ -133,9 +139,18 @@ class _WithdrawalProcessingDialogState extends State<WithdrawalProcessingDialog>
       withdrawalRequestHash: widget.requestHash,
     );
 
+    _busy = false;
     if (!mounted) return;
 
     debugPrint('$_tag completeWithdrawal result — success: ${result.success}, vfxTx: ${result.vfxTransactionHash}, btcTx: ${result.btcTransactionHash}, message: ${result.message}');
+
+    // A client-side timeout does not mean the ceremony failed — the CLI may
+    // still be signing and broadcasting. Offering Retry here risks a second
+    // Bitcoin transaction, so confirm the contract state first.
+    if (!result.success && result.timedOut) {
+      await _verifyWithdrawalSettled();
+      return;
+    }
 
     if (result.success) {
       notifyTransactionSubmitted();
@@ -144,6 +159,53 @@ class _WithdrawalProcessingDialogState extends State<WithdrawalProcessingDialog>
     setState(() {
       _result = result;
       _state = result.success ? _DialogState.success : _DialogState.failure;
+    });
+  }
+
+  /// Polls the contract until the request stops being the active withdrawal,
+  /// which means the CLI finished after our request timed out.
+  Future<void> _verifyWithdrawalSettled() async {
+    debugPrint('$_tag Request timed out — verifying contract state for ${widget.requestHash}');
+    setState(() => _state = _DialogState.verifying);
+
+    for (int i = 0; i < _maxVerificationPolls; i++) {
+      await Future.delayed(_confirmationPollInterval);
+      if (!mounted) return;
+
+      final stillActive = await VbtcV2Service().isWithdrawalStillActive(
+        scUid: widget.scUid,
+        withdrawalRequestHash: widget.requestHash,
+      );
+      if (!mounted) return;
+
+      debugPrint('$_tag Verification poll #${i + 1} — stillActive: $stillActive');
+
+      if (stillActive == false) {
+        notifyTransactionSubmitted();
+        setState(() {
+          _result = WithdrawalResult(
+            success: true,
+            requestHash: widget.requestHash,
+            message: "Withdrawal completed. It is no longer pending on the contract.",
+          );
+          _state = _DialogState.success;
+        });
+        return;
+      }
+    }
+
+    if (!mounted) return;
+
+    debugPrint('$_tag Verification exhausted — withdrawal still pending');
+    setState(() {
+      _result = WithdrawalResult(
+        success: false,
+        requestHash: widget.requestHash,
+        message: "The signing ceremony timed out and the withdrawal is still pending on the contract. "
+            "It may yet complete on its own — re-check the token before retrying, as retrying can "
+            "broadcast a second Bitcoin transaction.",
+      );
+      _state = _DialogState.failure;
     });
   }
 
@@ -157,7 +219,7 @@ class _WithdrawalProcessingDialogState extends State<WithdrawalProcessingDialog>
             _titleForState(),
             style: const TextStyle(color: Colors.white),
           ),
-          if (_state != _DialogState.processing && _state != _DialogState.waitingForBlock)
+          if (_isTerminal)
             IconButton(
               onPressed: () => Navigator.of(context).pop(_result),
               icon: const Icon(Icons.close, size: 20),
@@ -175,6 +237,7 @@ class _WithdrawalProcessingDialogState extends State<WithdrawalProcessingDialog>
           children: [
             if (_state == _DialogState.waitingForBlock) _buildWaitingForBlockSection(),
             if (_state == _DialogState.processing) _buildProcessingSection(),
+            if (_state == _DialogState.verifying) _buildVerifyingSection(),
             if (_state == _DialogState.success) _buildSuccessSection(),
             if (_state == _DialogState.failure) _buildFailureSection(),
           ],
@@ -183,12 +246,17 @@ class _WithdrawalProcessingDialogState extends State<WithdrawalProcessingDialog>
     );
   }
 
+  bool get _isTerminal =>
+      _state == _DialogState.success || _state == _DialogState.failure;
+
   String _titleForState() {
     switch (_state) {
       case _DialogState.waitingForBlock:
         return "Waiting for Confirmation";
       case _DialogState.processing:
         return "Processing Withdrawal";
+      case _DialogState.verifying:
+        return "Checking Withdrawal Status";
       case _DialogState.success:
         return "Withdrawal Complete";
       case _DialogState.failure:
@@ -240,6 +308,31 @@ class _WithdrawalProcessingDialogState extends State<WithdrawalProcessingDialog>
         SizedBox(height: 8),
         Text(
           "This may take a minute. Please do not close the application.",
+          style: TextStyle(color: Colors.white38, fontSize: 12),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildVerifyingSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: const [
+        Center(
+          child: SizedBox(
+            width: 32,
+            height: 32,
+            child: CircularProgressIndicator(strokeWidth: 3),
+          ),
+        ),
+        SizedBox(height: 16),
+        Text(
+          "The request timed out. Checking whether the withdrawal completed anyway...",
+          style: TextStyle(color: Colors.white70),
+        ),
+        SizedBox(height: 8),
+        Text(
+          "Signing can outlast the request. Please wait rather than retrying — retrying can broadcast a second Bitcoin transaction.",
           style: TextStyle(color: Colors.white38, fontSize: 12),
         ),
       ],
@@ -331,7 +424,7 @@ class _WithdrawalProcessingDialogState extends State<WithdrawalProcessingDialog>
             AppButton(
               label: "Retry",
               variant: AppColorVariant.Warning,
-              onPressed: _runCompleteWithdrawal,
+              onPressed: _busy ? null : _runCompleteWithdrawal,
             ),
           ],
         ),

--- a/lib/features/btc/models/withdrawal_result.dart
+++ b/lib/features/btc/models/withdrawal_result.dart
@@ -6,6 +6,12 @@ class WithdrawalResult {
   final String? btcTransactionHash;
   final String? status;
 
+  /// The request timed out client-side rather than being rejected. The CLI may
+  /// still be signing and broadcasting, so this must not be treated as a
+  /// failure until the contract state says otherwise — retrying blind can
+  /// produce a second Bitcoin transaction.
+  final bool timedOut;
+
   const WithdrawalResult({
     required this.success,
     this.message,
@@ -13,5 +19,6 @@ class WithdrawalResult {
     this.vfxTransactionHash,
     this.btcTransactionHash,
     this.status,
+    this.timedOut = false,
   });
 }

--- a/lib/features/btc/services/vbtc_v2_service.dart
+++ b/lib/features/btc/services/vbtc_v2_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 
 import '../../../utils/toast.dart';
@@ -22,7 +23,10 @@ void _log(String method, String message, [Map<String, dynamic>? json]) {
 class VbtcV2Service extends BaseService {
   VbtcV2Service() : super(apiBasePathOverride: "/vbtcapi/vbtc");
 
-  static final _activeWithdrawalPattern = RegExp(r'Request Hash:\s*((?:0x)?[a-fA-F0-9]+)');
+  /// FROST signing is budgeted 180s on the web wallet. Anything shorter here
+  /// times out the client while the CLI is still legitimately signing, which
+  /// surfaces a successful withdrawal as a failure.
+  static const _completeWithdrawalTimeoutMs = 180000;
 
   /// Fetch V2 contracts from the CLI endpoint.
   /// Returns them as [TokenizedBitcoin] with version=2 so the UI
@@ -326,7 +330,7 @@ class VbtcV2Service extends BaseService {
       'WithdrawalRequestHash': withdrawalRequestHash,
     };
 
-    _log(method, 'REQUEST POST /CompleteWithdrawal (timeout: 120s)', params);
+    _log(method, 'REQUEST POST /CompleteWithdrawal (timeout: ${_completeWithdrawalTimeoutMs ~/ 1000}s)', params);
 
     try {
       final stopwatch = Stopwatch()..start();
@@ -335,7 +339,7 @@ class VbtcV2Service extends BaseService {
         params: params,
         cleanPath: false,
         inspect: true,
-        timeout: 120000,
+        timeout: _completeWithdrawalTimeoutMs,
       );
       stopwatch.stop();
 
@@ -362,11 +366,51 @@ class VbtcV2Service extends BaseService {
       );
     } catch (e, st) {
       _log(method, 'EXCEPTION: $e\n$st');
+      final timedOut = _isTimeout(e);
       return WithdrawalResult(
         success: false,
-        message: e.toString(),
+        message: timedOut
+            ? "Timed out waiting for the signing ceremony to finish. The withdrawal may still be in progress."
+            : e.toString(),
         requestHash: withdrawalRequestHash,
+        timedOut: timedOut,
       );
+    }
+  }
+
+  static bool _isTimeout(Object e) {
+    if (e is! DioException) return false;
+    return e.type == DioExceptionType.connectionTimeout ||
+        e.type == DioExceptionType.sendTimeout ||
+        e.type == DioExceptionType.receiveTimeout;
+  }
+
+  /// Whether [withdrawalRequestHash] is still the contract's active withdrawal.
+  ///
+  /// Returns null when the contract state could not be read — callers must not
+  /// treat that as settled.
+  Future<bool?> isWithdrawalStillActive({
+    required String scUid,
+    required String withdrawalRequestHash,
+  }) async {
+    const method = 'IsWithdrawalStillActive';
+
+    try {
+      final contracts = await getContractList();
+      final match = contracts.where((c) => c.smartContractUid == scUid);
+
+      if (match.isEmpty) {
+        _log(method, 'Could not read contract state for scUid: $scUid');
+        return null;
+      }
+
+      final active = match.first.activeWithdrawalRequestHash;
+      final stillActive = active != null && active.isNotEmpty && active == withdrawalRequestHash;
+      _log(method, 'active: $active | checking: $withdrawalRequestHash | stillActive: $stillActive');
+      return stillActive;
+    } catch (e, st) {
+      _log(method, 'EXCEPTION: $e\n$st');
+      return null;
     }
   }
 
@@ -414,72 +458,5 @@ class VbtcV2Service extends BaseService {
       Toast.error(e.toString());
       return false;
     }
-  }
-
-  /// Combined withdraw helper: requests a withdrawal then completes it.
-  /// If an active withdrawal already exists, parses the request hash from
-  /// the error and proceeds to complete it.
-  Future<WithdrawalResult> withdraw({
-    required String scUid,
-    required String requestorAddress,
-    required String btcAddress,
-    required double amount,
-    required int feeRate,
-  }) async {
-    const method = 'Withdraw';
-    _log(method, 'Starting combined withdraw flow for scUid: $scUid, amount: $amount, feeRate: $feeRate');
-
-    // Step 1: Request withdrawal
-    final requestResult = await requestWithdrawal(
-      scUid: scUid,
-      requestorAddress: requestorAddress,
-      btcAddress: btcAddress,
-      amount: amount,
-      feeRate: feeRate,
-    );
-
-    String? requestHash = requestResult.requestHash;
-
-    if (!requestResult.success) {
-      // Check if there's an existing active withdrawal we can resume
-      final message = requestResult.message ?? "";
-      final match = _activeWithdrawalPattern.firstMatch(message);
-      if (match != null) {
-        requestHash = match.group(1);
-        _log(method, 'Detected active withdrawal — resuming with requestHash: $requestHash');
-      } else {
-        _log(method, 'Request failed with no active withdrawal to resume: $message');
-        Toast.error(requestResult.message ?? "Failed to request withdrawal.");
-        return requestResult;
-      }
-    }
-
-    if (requestHash == null) {
-      _log(method, 'No requestHash available — aborting');
-      return const WithdrawalResult(
-        success: false,
-        message: "No request hash returned from withdrawal request.",
-      );
-    }
-
-    _log(method, 'Step 2: Completing withdrawal via FROST signing — requestHash: $requestHash');
-
-    // Step 2: Complete withdrawal via FROST signing
-    final completeResult = await completeWithdrawal(
-      scUid: scUid,
-      withdrawalRequestHash: requestHash,
-    );
-
-    _log(method, 'Withdraw flow finished — success: ${completeResult.success}');
-
-    // Always include the requestHash in the result for retry support
-    return WithdrawalResult(
-      success: completeResult.success,
-      message: completeResult.message,
-      requestHash: requestHash,
-      vfxTransactionHash: completeResult.vfxTransactionHash,
-      btcTransactionHash: completeResult.btcTransactionHash,
-      status: completeResult.status,
-    );
   }
 }

--- a/lib/features/btc_web/components/web_btc_tokenized_action_buttons.dart
+++ b/lib/features/btc_web/components/web_btc_tokenized_action_buttons.dart
@@ -253,24 +253,20 @@ class WebTokenizedBtcActionButtons extends BaseComponent {
             }
 
             // Check for pending withdrawal to resume
-            if (token.isPendingWithdrawal && token.withdrawalRequests != null) {
-              final pending = token.withdrawalRequests!.where(
-                (wr) => wr['status'] == 'pending',
-              );
-              if (pending.isNotEmpty) {
-                final requestHash = pending.first['request_transaction_hash'] as String?;
-                if (requestHash != null) {
-                  WebV2WithdrawalDialog.show(
-                    scIdentifier: token.scIdentifier,
-                    requestorAddress: myAddress!,
-                    btcAddress: pending.first['btc_address'] ?? '',
-                    amount: (pending.first['amount'] is num) ? (pending.first['amount'] as num).toDouble() : (double.tryParse(pending.first['amount'].toString()) ?? 0),
-                    feeRate: 0,
-                    ownerAddress: token.ownerAddress,
-                    existingRequestHash: requestHash,
-                  );
-                  return;
-                }
+            final pending = token.resumableWithdrawalRequests;
+            if (pending.isNotEmpty) {
+              final requestHash = pending.first['request_transaction_hash'] as String?;
+              if (requestHash != null) {
+                WebV2WithdrawalDialog.show(
+                  scIdentifier: token.scIdentifier,
+                  requestorAddress: myAddress!,
+                  btcAddress: pending.first['btc_address'] ?? '',
+                  amount: (pending.first['amount'] is num) ? (pending.first['amount'] as num).toDouble() : (double.tryParse(pending.first['amount'].toString()) ?? 0),
+                  feeRate: 0,
+                  ownerAddress: token.ownerAddress,
+                  existingRequestHash: requestHash,
+                );
+                return;
               }
             }
 

--- a/lib/features/btc_web/components/web_v2_withdrawal_dialog.dart
+++ b/lib/features/btc_web/components/web_v2_withdrawal_dialog.dart
@@ -12,8 +12,19 @@ import '../../../core/services/explorer_service.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../utils/toast.dart';
 import '../../token/providers/web_token_actions_manager.dart';
+import '../services/pending_withdrawal_completion_service.dart';
 
-enum _DialogStep { broadcasting, waitingForBlock, frostSigning, success, failure }
+enum _DialogStep {
+  broadcasting,
+  waitingForBlock,
+  frostSigning,
+  recordingCompletion,
+  success,
+  /// BTC sent, but the Type 28 completion TX is not on chain yet. Retriable
+  /// without touching Bitcoin again.
+  completionPending,
+  failure,
+}
 
 class WebV2WithdrawalDialog extends ConsumerStatefulWidget {
   final String scIdentifier;
@@ -74,13 +85,23 @@ class _WebV2WithdrawalDialogState extends ConsumerState<WebV2WithdrawalDialog> {
   int _pollCount = 0;
   static const _maxPollAttempts = 60; // 5 minutes at 5s intervals
 
+  /// Guards the retry buttons so a double tap cannot start two FROST sessions
+  /// or two completion sends.
+  bool _busy = false;
+
+  /// Set when the BTC broadcast returned no txid — retrying would re-sign
+  /// against spent inputs, so no retry is offered.
+  bool _btcBroadcastUnconfirmed = false;
+
   @override
   void initState() {
     super.initState();
     if (widget.existingRequestHash != null) {
       _requestHash = widget.existingRequestHash;
-      _step = _DialogStep.frostSigning;
-      Future(_runFrostSigning);
+      _step = PendingWithdrawalCompletionService().get(_requestHash!) != null
+          ? _DialogStep.recordingCompletion
+          : _DialogStep.frostSigning;
+      Future(_startCompletion);
     } else {
       Future(_broadcastRequest);
     }
@@ -153,8 +174,25 @@ class _WebV2WithdrawalDialogState extends ConsumerState<WebV2WithdrawalDialog> {
     });
   }
 
+  /// Resume point for an existing request. If a previous attempt already
+  /// broadcast the Bitcoin transaction, only the completion TX is retried —
+  /// re-running FROST would sign against spent inputs.
+  Future<void> _startCompletion() async {
+    final stored = PendingWithdrawalCompletionService().get(_requestHash!);
+    if (stored != null) {
+      await _recordCompletion(stored);
+      return;
+    }
+    await _runFrostSigning();
+  }
+
   Future<void> _runFrostSigning() async {
-    setState(() => _step = _DialogStep.frostSigning);
+    if (_busy) return;
+    _busy = true;
+    setState(() {
+      _step = _DialogStep.frostSigning;
+      _errorMessage = null;
+    });
 
     final manager = ref.read(webTokenActionsManager);
     final result = await manager.completeV2Withdrawal(
@@ -162,19 +200,72 @@ class _WebV2WithdrawalDialogState extends ConsumerState<WebV2WithdrawalDialog> {
       requestHash: _requestHash!,
     );
 
+    _busy = false;
     if (!mounted) return;
 
     if (result != null && result['success'] == true) {
       setState(() {
-        _step = _DialogStep.success;
         _btcTxHash = result['btc_transaction_hash'];
+        if (result['completion_recorded'] == true) {
+          _step = _DialogStep.success;
+        } else {
+          _step = _DialogStep.completionPending;
+          _errorMessage = result['completion_message'];
+        }
       });
-    } else {
-      setState(() {
-        _step = _DialogStep.failure;
-        _errorMessage = result?['message'] ?? "FROST signing failed or timed out. The withdrawal may still complete — check back shortly.";
-      });
+      return;
     }
+
+    setState(() {
+      _btcBroadcastUnconfirmed = result?['btc_broadcast_unconfirmed'] == true;
+      _step = _DialogStep.failure;
+      _errorMessage = result?['message'] ?? "FROST signing failed or timed out. The withdrawal may still complete — check back shortly.";
+    });
+  }
+
+  Future<void> _recordCompletion(PendingWithdrawalCompletion pending) async {
+    if (_busy) return;
+    _busy = true;
+    setState(() {
+      _step = _DialogStep.recordingCompletion;
+      _btcTxHash = pending.btcTxHash;
+      _errorMessage = null;
+    });
+
+    final manager = ref.read(webTokenActionsManager);
+    final result = await manager.recordV2WithdrawalCompletion(
+      scIdentifier: pending.scIdentifier,
+      requestHash: pending.requestHash,
+      btcTxHash: pending.btcTxHash,
+      amount: pending.amount,
+      btcDestination: pending.btcDestination,
+    );
+
+    _busy = false;
+    if (!mounted) return;
+
+    setState(() {
+      if (result['success'] == true) {
+        _step = _DialogStep.success;
+      } else {
+        _step = _DialogStep.completionPending;
+        _errorMessage = result['message'];
+      }
+    });
+  }
+
+  Future<void> _retryCompletion() async {
+    final stored = PendingWithdrawalCompletionService().get(_requestHash!);
+    if (stored == null) {
+      // The record is cleared only once the completion TX is broadcast, so
+      // its absence means a prior attempt landed after all.
+      setState(() {
+        _step = _DialogStep.success;
+        _errorMessage = null;
+      });
+      return;
+    }
+    await _recordCompletion(stored);
   }
 
   @override
@@ -187,7 +278,7 @@ class _WebV2WithdrawalDialogState extends ConsumerState<WebV2WithdrawalDialog> {
             _titleForStep(),
             style: const TextStyle(color: Colors.white),
           ),
-          if (_step == _DialogStep.success || _step == _DialogStep.failure)
+          if (_isTerminal)
             IconButton(
               onPressed: () => Navigator.of(context).pop(),
               icon: const Icon(Icons.close, size: 20),
@@ -206,13 +297,20 @@ class _WebV2WithdrawalDialogState extends ConsumerState<WebV2WithdrawalDialog> {
             if (_step == _DialogStep.broadcasting) _buildBroadcastingSection(),
             if (_step == _DialogStep.waitingForBlock) _buildWaitingSection(),
             if (_step == _DialogStep.frostSigning) _buildFrostSigningSection(),
+            if (_step == _DialogStep.recordingCompletion) _buildRecordingSection(),
             if (_step == _DialogStep.success) _buildSuccessSection(),
+            if (_step == _DialogStep.completionPending) _buildCompletionPendingSection(),
             if (_step == _DialogStep.failure) _buildFailureSection(),
           ],
         ),
       ),
     );
   }
+
+  bool get _isTerminal =>
+      _step == _DialogStep.success ||
+      _step == _DialogStep.failure ||
+      _step == _DialogStep.completionPending;
 
   String _titleForStep() {
     switch (_step) {
@@ -222,8 +320,12 @@ class _WebV2WithdrawalDialogState extends ConsumerState<WebV2WithdrawalDialog> {
         return "Waiting for Confirmation";
       case _DialogStep.frostSigning:
         return "FROST Signing";
+      case _DialogStep.recordingCompletion:
+        return "Recording Completion";
       case _DialogStep.success:
         return "Withdrawal Complete";
+      case _DialogStep.completionPending:
+        return "Action Required";
       case _DialogStep.failure:
         return "Withdrawal Failed";
     }
@@ -264,6 +366,78 @@ class _WebV2WithdrawalDialogState extends ConsumerState<WebV2WithdrawalDialog> {
         Text("FROST signing in progress...", style: TextStyle(color: Colors.white70)),
         SizedBox(height: 8),
         Text("Validators are signing the Bitcoin transaction. This may take a minute or two. Please do not close this window.", style: TextStyle(color: Colors.white38, fontSize: 12)),
+      ],
+    );
+  }
+
+  Widget _buildRecordingSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: const [
+        Center(child: SizedBox(width: 32, height: 32, child: CircularProgressIndicator(strokeWidth: 3))),
+        SizedBox(height: 16),
+        Text("Recording completion on the VFX chain...", style: TextStyle(color: Colors.white70)),
+        SizedBox(height: 8),
+        Text("The Bitcoin transaction has been broadcast. This final transaction settles the withdrawal on chain.",
+            style: TextStyle(color: Colors.white38, fontSize: 12)),
+      ],
+    );
+  }
+
+  Widget _buildCompletionPendingSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: const [
+            Icon(Icons.warning_amber_rounded, color: Color(0xFFE0A32E), size: 20),
+            SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                "Your Bitcoin was sent, but the withdrawal has not been settled on the VFX chain yet.",
+                style: TextStyle(color: Colors.white, fontWeight: FontWeight.w500),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        const Text(
+          "Retry below to finish. This only submits the completion transaction — your Bitcoin will not be sent again. "
+          "You can also come back to this from the token's withdrawal history.",
+          style: TextStyle(color: Colors.white38, fontSize: 12),
+        ),
+        if (_errorMessage != null) ...[
+          const SizedBox(height: 12),
+          Text(_errorMessage!, style: const TextStyle(color: Color(0xFFBA2121), fontSize: 12)),
+        ],
+        if (_btcTxHash != null) ...[
+          const SizedBox(height: 16),
+          _buildHashRow(
+            "BTC Transaction:",
+            _btcTxHash!,
+            explorerUrl: Env.btcIsTestNet
+                ? "https://mempool.space/testnet4/tx/$_btcTxHash"
+                : "https://mempool.space/tx/$_btcTxHash",
+          ),
+        ],
+        const SizedBox(height: 20),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            AppButton(
+              label: "Later",
+              variant: AppColorVariant.Light,
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+            const SizedBox(width: 8),
+            AppButton(
+              label: "Retry Completion",
+              variant: AppColorVariant.Warning,
+              onPressed: _busy ? null : _retryCompletion,
+            ),
+          ],
+        ),
       ],
     );
   }
@@ -328,12 +502,14 @@ class _WebV2WithdrawalDialogState extends ConsumerState<WebV2WithdrawalDialog> {
               variant: AppColorVariant.Light,
               onPressed: () => Navigator.of(context).pop(),
             ),
-            if (_requestHash != null) ...[
+            // No retry when the BTC broadcast succeeded without returning a
+            // txid — signing again would spend inputs that are already gone.
+            if (_requestHash != null && !_btcBroadcastUnconfirmed) ...[
               const SizedBox(width: 8),
               AppButton(
                 label: "Retry Signing",
                 variant: AppColorVariant.Warning,
-                onPressed: _runFrostSigning,
+                onPressed: _busy ? null : _runFrostSigning,
               ),
             ],
           ],

--- a/lib/features/btc_web/components/web_v2_withdrawal_dialog.dart
+++ b/lib/features/btc_web/components/web_v2_withdrawal_dialog.dart
@@ -93,6 +93,14 @@ class _WebV2WithdrawalDialogState extends ConsumerState<WebV2WithdrawalDialog> {
   /// against spent inputs, so no retry is offered.
   bool _btcBroadcastUnconfirmed = false;
 
+  /// The broadcast this dialog is trying to settle, held in memory so a retry
+  /// never depends on storage — which may be the thing that failed.
+  PendingWithdrawalCompletion? _pendingCompletion;
+
+  /// False when the recovery record could not be persisted, so this withdrawal
+  /// cannot be resumed after the page closes.
+  bool _completionRecoverable = true;
+
   @override
   void initState() {
     super.initState();
@@ -180,6 +188,7 @@ class _WebV2WithdrawalDialogState extends ConsumerState<WebV2WithdrawalDialog> {
   Future<void> _startCompletion() async {
     final stored = PendingWithdrawalCompletionService().get(_requestHash!);
     if (stored != null) {
+      _pendingCompletion = stored;
       await _recordCompletion(stored);
       return;
     }
@@ -204,8 +213,25 @@ class _WebV2WithdrawalDialogState extends ConsumerState<WebV2WithdrawalDialog> {
     if (!mounted) return;
 
     if (result != null && result['success'] == true) {
+      final btcTxHash = result['btc_transaction_hash'] as String?;
+
+      // Held in memory so Retry Completion works even when the recovery write
+      // failed. Storage is the fallback, not the source of truth.
+      if (btcTxHash != null) {
+        _pendingCompletion = PendingWithdrawalCompletion(
+          scIdentifier: widget.scIdentifier,
+          requestHash: _requestHash!,
+          btcTxHash: btcTxHash,
+          amount: (result['withdrawal_amount'] as num?)?.toDouble() ?? widget.amount,
+          btcDestination: result['btc_destination'] as String? ?? widget.btcAddress,
+          fromAddress: widget.requestorAddress,
+          createdAt: DateTime.now(),
+        );
+      }
+
       setState(() {
-        _btcTxHash = result['btc_transaction_hash'];
+        _btcTxHash = btcTxHash;
+        _completionRecoverable = result['completion_recoverable'] != false;
         if (result['completion_recorded'] == true) {
           _step = _DialogStep.success;
         } else {
@@ -226,6 +252,7 @@ class _WebV2WithdrawalDialogState extends ConsumerState<WebV2WithdrawalDialog> {
   Future<void> _recordCompletion(PendingWithdrawalCompletion pending) async {
     if (_busy) return;
     _busy = true;
+    _pendingCompletion = pending;
     setState(() {
       _step = _DialogStep.recordingCompletion;
       _btcTxHash = pending.btcTxHash;
@@ -255,17 +282,25 @@ class _WebV2WithdrawalDialogState extends ConsumerState<WebV2WithdrawalDialog> {
   }
 
   Future<void> _retryCompletion() async {
-    final stored = PendingWithdrawalCompletionService().get(_requestHash!);
-    if (stored == null) {
-      // The record is cleared only once the completion TX is broadcast, so
-      // its absence means a prior attempt landed after all.
+    // Prefer the in-memory broadcast. A missing storage record proves nothing:
+    // it means either the completion landed and cleared it, or the recovery
+    // write failed in the first place. Treating absence as settlement would
+    // report an unsettled withdrawal as complete.
+    final pending = _pendingCompletion ??
+        PendingWithdrawalCompletionService().get(_requestHash!);
+
+    if (pending == null) {
       setState(() {
-        _step = _DialogStep.success;
-        _errorMessage = null;
+        _step = _DialogStep.failure;
+        _errorMessage = "Could not determine the Bitcoin transaction for this withdrawal, "
+            "so it cannot be settled automatically. Check the destination address on a "
+            "block explorer and contact support before retrying — retrying may broadcast "
+            "a second Bitcoin transaction.";
       });
       return;
     }
-    await _recordCompletion(stored);
+
+    await _recordCompletion(pending);
   }
 
   @override
@@ -402,10 +437,17 @@ class _WebV2WithdrawalDialogState extends ConsumerState<WebV2WithdrawalDialog> {
           ],
         ),
         const SizedBox(height: 12),
-        const Text(
-          "Retry below to finish. This only submits the completion transaction — your Bitcoin will not be sent again. "
-          "You can also come back to this from the token's withdrawal history.",
-          style: TextStyle(color: Colors.white38, fontSize: 12),
+        Text(
+          _completionRecoverable
+              ? "Retry below to finish. This only submits the completion transaction — your Bitcoin will not be sent again. "
+                  "You can also come back to this from the token's withdrawal history."
+              : "Retry below to finish. This only submits the completion transaction — your Bitcoin will not be sent again. "
+                  "This withdrawal could not be saved for later recovery, so do not close this page before it succeeds. "
+                  "Copy the Bitcoin transaction ID below first.",
+          style: TextStyle(
+            color: _completionRecoverable ? Colors.white38 : const Color(0xFFE0A32E),
+            fontSize: 12,
+          ),
         ),
         if (_errorMessage != null) ...[
           const SizedBox(height: 12),
@@ -425,12 +467,16 @@ class _WebV2WithdrawalDialogState extends ConsumerState<WebV2WithdrawalDialog> {
         Row(
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
-            AppButton(
-              label: "Later",
-              variant: AppColorVariant.Light,
-              onPressed: () => Navigator.of(context).pop(),
-            ),
-            const SizedBox(width: 8),
+            // Deferring is only safe when the withdrawal can be picked up
+            // again later, so it is not offered when the record failed to save.
+            if (_completionRecoverable) ...[
+              AppButton(
+                label: "Later",
+                variant: AppColorVariant.Light,
+                onPressed: () => Navigator.of(context).pop(),
+              ),
+              const SizedBox(width: 8),
+            ],
             AppButton(
               label: "Retry Completion",
               variant: AppColorVariant.Warning,

--- a/lib/features/btc_web/models/btc_web_vbtc_token.dart
+++ b/lib/features/btc_web/models/btc_web_vbtc_token.dart
@@ -5,6 +5,15 @@ import '../../nft/models/web_nft.dart';
 part 'btc_web_vbtc_token.freezed.dart';
 part 'btc_web_vbtc_token.g.dart';
 
+/// Withdrawal request statuses that still need completing. The API has used
+/// both spellings, and treating only one as resumable strands the other in a
+/// state where the UI offers a fresh request instead of finishing the existing
+/// one.
+const kResumableWithdrawalStatuses = {'pending', 'requested'};
+
+bool withdrawalIsResumable(Map<String, dynamic> withdrawalRequest) =>
+    kResumableWithdrawalStatuses.contains(withdrawalRequest['status']);
+
 @freezed
 class BtcWebVbtcToken with _$BtcWebVbtcToken {
   const BtcWebVbtcToken._();
@@ -30,6 +39,9 @@ class BtcWebVbtcToken with _$BtcWebVbtcToken {
   }) = _BtcWebVbtcToken;
 
   factory BtcWebVbtcToken.fromJson(Map<String, dynamic> json) => _$BtcWebVbtcTokenFromJson(json);
+
+  List<Map<String, dynamic>> get resumableWithdrawalRequests =>
+      (withdrawalRequests ?? []).where(withdrawalIsResumable).toList();
 
   double balanceForAddress(String? address) {
     if (address == null) {

--- a/lib/features/btc_web/screens/web_tokenized_btc_detail_screen.dart
+++ b/lib/features/btc_web/screens/web_tokenized_btc_detail_screen.dart
@@ -28,6 +28,7 @@ import '../components/web_btc_transaction_list_tile.dart';
 import '../components/web_v2_withdrawal_dialog.dart';
 import '../models/btc_web_vbtc_token.dart';
 import '../providers/btc_web_vbtc_token_detail_provider.dart';
+import '../services/pending_withdrawal_completion_service.dart';
 
 class WebTokenizedBtcDetailScreen extends BaseScreen {
   final String scIdentifier;
@@ -235,15 +236,27 @@ class WebTokenizedBtcDetailScreen extends BaseScreen {
                       final status = wr['status'] ?? 'unknown';
                       final amount = wr['amount'];
                       final btcAddr = wr['btc_address'] ?? '';
-                      final isRequested = status == 'requested' || status == 'pending';
+                      final isRequested = withdrawalIsResumable(wr);
+                      final unrecorded = PendingWithdrawalCompletionService().get(
+                        wr['request_transaction_hash'] ?? '',
+                      );
                       return Padding(
                         padding: const EdgeInsets.only(bottom: 8.0),
                         child: AppCard(
                           padding: 8,
                           child: ListTile(
                             title: Text("$amount vBTC → $btcAddr"),
-                            subtitle: Text(isRequested ? "Pending — tap to resume" : "Status: $status"),
-                            onTap: isRequested
+                            subtitle: Text(
+                              unrecorded != null
+                                  ? "BTC sent — tap to finish settling on VFX"
+                                  : isRequested
+                                      ? "Pending — tap to resume"
+                                      : "Status: $status",
+                              style: unrecorded != null
+                                  ? const TextStyle(color: Color(0xFFE0A32E))
+                                  : null,
+                            ),
+                            onTap: isRequested || unrecorded != null
                                 ? () {
                                     final requestHash = wr['request_transaction_hash'] as String?;
                                     if (requestHash != null) {
@@ -259,28 +272,32 @@ class WebTokenizedBtcDetailScreen extends BaseScreen {
                                     }
                                   }
                                 : null,
-                            trailing: isRequested
-                                ? IconButton(
-                                    icon: const Icon(Icons.cancel, color: Colors.redAccent, size: 20),
-                                    tooltip: "Cancel withdrawal",
-                                    onPressed: () async {
-                                      final confirmed = await ConfirmDialog.show(
-                                        title: "Cancel Withdrawal?",
-                                        body: "Are you sure you want to cancel this withdrawal request?",
-                                      );
-                                      if (confirmed == true) {
-                                        final manager = ref.read(webTokenActionsManager);
-                                        await manager.cancelV2Withdrawal(
-                                          scIdentifier: token.scIdentifier,
-                                          ownerAddress: token.ownerAddress,
-                                          requestHash: wr['request_transaction_hash'] ?? '',
-                                        );
-                                      }
-                                    },
-                                  )
-                                : status == 'completed'
-                                    ? const Icon(Icons.check_circle, color: Colors.green)
-                                    : const Icon(Icons.pending, color: Colors.orange),
+                            // Cancelling is only meaningful before the BTC goes
+                            // out; once it has, the request must be settled.
+                            trailing: unrecorded != null
+                                ? const Icon(Icons.warning_amber_rounded, color: Color(0xFFE0A32E))
+                                : isRequested
+                                    ? IconButton(
+                                        icon: const Icon(Icons.cancel, color: Colors.redAccent, size: 20),
+                                        tooltip: "Cancel withdrawal",
+                                        onPressed: () async {
+                                          final confirmed = await ConfirmDialog.show(
+                                            title: "Cancel Withdrawal?",
+                                            body: "Are you sure you want to cancel this withdrawal request?",
+                                          );
+                                          if (confirmed == true) {
+                                            final manager = ref.read(webTokenActionsManager);
+                                            await manager.cancelV2Withdrawal(
+                                              scIdentifier: token.scIdentifier,
+                                              ownerAddress: token.ownerAddress,
+                                              requestHash: wr['request_transaction_hash'] ?? '',
+                                            );
+                                          }
+                                        },
+                                      )
+                                    : status == 'completed'
+                                        ? const Icon(Icons.check_circle, color: Colors.green)
+                                        : const Icon(Icons.pending, color: Colors.orange),
                           ),
                         ),
                       );

--- a/lib/features/btc_web/services/pending_withdrawal_completion_service.dart
+++ b/lib/features/btc_web/services/pending_withdrawal_completion_service.dart
@@ -64,21 +64,28 @@ class PendingWithdrawalCompletionService {
     }
   }
 
-  void _writeRaw(Map<String, dynamic> data) {
+  bool _writeRaw(Map<String, dynamic> data) {
     try {
       singleton<Storage>().setMap(_key, data);
+      return true;
     } catch (e) {
       print("Failed to persist pending withdrawal completions: $e");
+      return false;
     }
   }
 
   /// Record that [btcTxHash] was broadcast for [requestHash] but not yet
   /// settled on the VFX chain. Call this immediately after a successful BTC
   /// broadcast, before attempting the completion TX.
-  void record(PendingWithdrawalCompletion entry) {
+  ///
+  /// Returns false if the record could not be persisted. Callers must not
+  /// ignore that: without it there is no durable reference to the broadcast
+  /// Bitcoin transaction, so the withdrawal cannot be recovered in a later
+  /// session and must be finished — or at least surfaced — now.
+  bool record(PendingWithdrawalCompletion entry) {
     final data = _readRaw();
     data[entry.requestHash] = entry.toJson();
-    _writeRaw(data);
+    return _writeRaw(data);
   }
 
   PendingWithdrawalCompletion? get(String requestHash) {

--- a/lib/features/btc_web/services/pending_withdrawal_completion_service.dart
+++ b/lib/features/btc_web/services/pending_withdrawal_completion_service.dart
@@ -1,0 +1,123 @@
+import '../../../core/singletons.dart';
+import '../../../core/storage.dart';
+
+/// A vBTC V2 withdrawal whose Bitcoin transaction has been broadcast but whose
+/// Type 28 completion transaction has not yet been recorded on the VFX chain.
+///
+/// The BTC broadcast and the completion TX are two separate network calls. If
+/// the browser tab dies between them — or the completion TX send fails — the
+/// coins have left the vault with nothing on chain to settle the withdrawal.
+/// Persisting the pair lets us finish the job on a later session instead of
+/// re-running FROST against already-spent inputs.
+class PendingWithdrawalCompletion {
+  final String scIdentifier;
+  final String requestHash;
+  final String btcTxHash;
+  final double amount;
+  final String btcDestination;
+  final String fromAddress;
+  final DateTime createdAt;
+
+  const PendingWithdrawalCompletion({
+    required this.scIdentifier,
+    required this.requestHash,
+    required this.btcTxHash,
+    required this.amount,
+    required this.btcDestination,
+    required this.fromAddress,
+    required this.createdAt,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'sc_identifier': scIdentifier,
+        'request_hash': requestHash,
+        'btc_tx_hash': btcTxHash,
+        'amount': amount,
+        'btc_destination': btcDestination,
+        'from_address': fromAddress,
+        'created_at': createdAt.toIso8601String(),
+      };
+
+  factory PendingWithdrawalCompletion.fromJson(Map<String, dynamic> json) {
+    return PendingWithdrawalCompletion(
+      scIdentifier: json['sc_identifier'] ?? '',
+      requestHash: json['request_hash'] ?? '',
+      btcTxHash: json['btc_tx_hash'] ?? '',
+      amount: (json['amount'] as num?)?.toDouble() ?? 0,
+      btcDestination: json['btc_destination'] ?? '',
+      fromAddress: json['from_address'] ?? '',
+      createdAt:
+          DateTime.tryParse(json['created_at'] ?? '') ?? DateTime.now(),
+    );
+  }
+}
+
+class PendingWithdrawalCompletionService {
+  static const _key = Storage.PENDING_VBTC_WITHDRAWAL_COMPLETIONS;
+
+  Map<String, dynamic> _readRaw() {
+    try {
+      return singleton<Storage>().getMap(_key) ?? {};
+    } catch (e) {
+      print("Failed to read pending withdrawal completions: $e");
+      return {};
+    }
+  }
+
+  void _writeRaw(Map<String, dynamic> data) {
+    try {
+      singleton<Storage>().setMap(_key, data);
+    } catch (e) {
+      print("Failed to persist pending withdrawal completions: $e");
+    }
+  }
+
+  /// Record that [btcTxHash] was broadcast for [requestHash] but not yet
+  /// settled on the VFX chain. Call this immediately after a successful BTC
+  /// broadcast, before attempting the completion TX.
+  void record(PendingWithdrawalCompletion entry) {
+    final data = _readRaw();
+    data[entry.requestHash] = entry.toJson();
+    _writeRaw(data);
+  }
+
+  PendingWithdrawalCompletion? get(String requestHash) {
+    final raw = _readRaw()[requestHash];
+    if (raw == null) return null;
+    try {
+      return PendingWithdrawalCompletion.fromJson(
+          Map<String, dynamic>.from(raw));
+    } catch (e) {
+      print("Failed to parse pending withdrawal completion: $e");
+      return null;
+    }
+  }
+
+  /// All unrecorded completions, newest first.
+  List<PendingWithdrawalCompletion> all() {
+    final entries = <PendingWithdrawalCompletion>[];
+    for (final raw in _readRaw().values) {
+      try {
+        entries.add(
+            PendingWithdrawalCompletion.fromJson(Map<String, dynamic>.from(raw)));
+      } catch (e) {
+        print("Skipping malformed pending withdrawal completion: $e");
+      }
+    }
+    entries.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    return entries;
+  }
+
+  List<PendingWithdrawalCompletion> forAddress(String? address) {
+    if (address == null) return [];
+    return all().where((e) => e.fromAddress == address).toList();
+  }
+
+  /// Drop the record once the completion TX is on chain.
+  void clear(String requestHash) {
+    final data = _readRaw();
+    if (data.remove(requestHash) != null) {
+      _writeRaw(data);
+    }
+  }
+}

--- a/lib/features/token/providers/web_token_actions_manager.dart
+++ b/lib/features/token/providers/web_token_actions_manager.dart
@@ -15,6 +15,7 @@ import '../../../core/providers/web_session_provider.dart';
 import '../../../utils/toast.dart';
 import '../../../utils/validation.dart';
 import '../../btc_web/models/btc_web_vbtc_token.dart';
+import '../../btc_web/services/pending_withdrawal_completion_service.dart';
 import '../../global_loader/global_loading_provider.dart';
 import '../../keygen/models/keypair.dart';
 import '../../keygen/models/ra_keypair.dart';
@@ -527,7 +528,95 @@ class WebTokenActionsManager {
     }
   }
 
+  /// Records the Type 28 completion TX on the VFX chain for a withdrawal whose
+  /// Bitcoin transaction has already been broadcast.
+  ///
+  /// This is the transaction that actually settles the withdrawal on chain — if
+  /// it never lands, the BTC has left the vault but the contract still shows the
+  /// request as pending. It is therefore reported and retried independently of
+  /// the FROST signing, and must never be silently skipped.
+  Future<Map<String, dynamic>> recordV2WithdrawalCompletion({
+    required String scIdentifier,
+    required String requestHash,
+    required String btcTxHash,
+    required double amount,
+    required String btcDestination,
+  }) async {
+    final keypair = ref.read(webSessionProvider).keypair;
+    if (keypair == null) {
+      return {'success': false, 'message': 'No keypair found to sign the completion transaction'};
+    }
+
+    try {
+      final prepared = await ExplorerService().prepareV2WithdrawalCompleteTx(
+        scIdentifier: scIdentifier,
+        fromAddress: keypair.address,
+        withdrawalRequestHash: requestHash,
+        btcTransactionHash: btcTxHash,
+        amount: amount,
+        btcDestination: btcDestination,
+      );
+
+      if (prepared['success'] != true || prepared['Hash'] == null) {
+        return {
+          'success': false,
+          'message': prepared['message'] ?? 'Failed to prepare the completion transaction',
+        };
+      }
+
+      final hash = prepared['Hash'] as String;
+
+      final signature = await RawTransaction.getSignature(
+        message: hash,
+        privateKey: keypair.private,
+        publicKey: keypair.public,
+      );
+
+      if (signature == null) {
+        return {'success': false, 'message': 'Failed to sign the completion transaction'};
+      }
+
+      final result = await ExplorerService().sendV2WithdrawalCompleteTx(
+        hash: hash,
+        signature: signature,
+        publicKey: keypair.public,
+      );
+
+      if (result['success'] != true) {
+        return {
+          'success': false,
+          'message': result['message'] ?? 'Failed to broadcast the completion transaction',
+        };
+      }
+
+      final completionHash = (result['Hash'] as String?) ?? hash;
+
+      ref.read(webTransactionListProvider(keypair.address).notifier).insertPendingTx(
+        WebTransaction(
+          hash: completionHash,
+          toAddress: keypair.address,
+          fromAddress: keypair.address,
+          type: TxType.vbtcV2WithdrawalComplete,
+          amount: 0,
+          fee: 0,
+          date: DateTime.now(),
+          height: 0,
+        ),
+      );
+
+      PendingWithdrawalCompletionService().clear(requestHash);
+
+      return {'success': true, 'hash': completionHash};
+    } catch (e) {
+      return {'success': false, 'message': 'Completion transaction failed: $e'};
+    }
+  }
+
   /// V2 withdrawal complete via prepare→sign two messages→execute→broadcast BTC.
+  ///
+  /// If a previous attempt already broadcast the Bitcoin transaction, this skips
+  /// FROST entirely and only retries the completion TX — re-running the ceremony
+  /// would sign against already-spent inputs.
   Future<Map<String, dynamic>?> completeV2Withdrawal({
     required String scIdentifier,
     required String requestHash,
@@ -536,6 +625,24 @@ class WebTokenActionsManager {
     if (keypair == null) {
       Toast.error("No keypair found");
       return null;
+    }
+
+    final alreadyBroadcast = PendingWithdrawalCompletionService().get(requestHash);
+    if (alreadyBroadcast != null) {
+      final recorded = await recordV2WithdrawalCompletion(
+        scIdentifier: scIdentifier,
+        requestHash: requestHash,
+        btcTxHash: alreadyBroadcast.btcTxHash,
+        amount: alreadyBroadcast.amount,
+        btcDestination: alreadyBroadcast.btcDestination,
+      );
+
+      return {
+        'success': true,
+        'btc_transaction_hash': alreadyBroadcast.btcTxHash,
+        'completion_recorded': recorded['success'] == true,
+        'completion_message': recorded['message'],
+      };
     }
 
     try {
@@ -555,6 +662,8 @@ class WebTokenActionsManager {
       final shareMessage = prepared['ShareDistributionMessage'] as String;
       final shareTimestamp = prepared['ShareDistributionTimestamp'] as int;
       final sessionId = prepared['SessionId'] as String;
+      final withdrawalAmount = (prepared['Amount'] as num?)?.toDouble() ?? 0;
+      final btcDestination = prepared['BTCDestination'] as String? ?? '';
 
       // Step 2: Sign both messages (same pattern as ceremony)
       final startSig = await RawTransaction.getSignature(
@@ -583,8 +692,8 @@ class WebTokenActionsManager {
         startTimestamp: startTimestamp,
         shareDistributionSignature: shareSig,
         shareDistributionTimestamp: shareTimestamp,
-        amount: (prepared['Amount'] as num?)?.toDouble() ?? 0,
-        btcDestination: prepared['BTCDestination'] as String? ?? '',
+        amount: withdrawalAmount,
+        btcDestination: btcDestination,
         feeRate: prepared['FeeRate'] as int? ?? 0,
       );
 
@@ -634,42 +743,51 @@ class WebTokenActionsManager {
         };
       }
 
-      final btcTxHash = broadcastResult['txid'] as String;
+      final btcTxHash = broadcastResult['txid'] as String?;
+
+      // The broadcast succeeded, so the BTC has left the vault even though we
+      // cannot name the transaction. Retrying FROST here would sign against
+      // spent inputs, so this gets its own terminal state rather than being
+      // reported as a signing failure.
+      if (btcTxHash == null || btcTxHash.isEmpty) {
+        return {
+          'success': false,
+          'btc_broadcast_unconfirmed': true,
+          'message': 'The Bitcoin transaction was broadcast but no transaction ID was returned. '
+              'Do not retry — check the destination address on a block explorer and contact support '
+              'so the withdrawal can be settled manually.',
+          'SignedBTCTxHex': signedBtcTxHex,
+        };
+      }
+
+      // Persist before attempting the completion TX. From here on the BTC is
+      // gone, so a closed tab or a failed send must still be recoverable.
+      PendingWithdrawalCompletionService().record(
+        PendingWithdrawalCompletion(
+          scIdentifier: scIdentifier,
+          requestHash: requestHash,
+          btcTxHash: btcTxHash,
+          amount: withdrawalAmount,
+          btcDestination: btcDestination,
+          fromAddress: keypair.address,
+          createdAt: DateTime.now(),
+        ),
+      );
 
       // Step 6: Record completion on VFX chain (Type 28 TX)
-      try {
-        final completePrepared = await ExplorerService().prepareV2WithdrawalCompleteTx(
-          scIdentifier: scIdentifier,
-          fromAddress: keypair.address,
-          withdrawalRequestHash: requestHash,
-          btcTransactionHash: btcTxHash,
-          amount: (prepared['Amount'] as num?)?.toDouble() ?? 0,
-          btcDestination: prepared['BTCDestination'] as String? ?? '',
-        );
-
-        if (completePrepared['success'] == true && completePrepared['Hash'] != null) {
-          final completeSig = await RawTransaction.getSignature(
-            message: completePrepared['Hash'] as String,
-            privateKey: keypair.private,
-            publicKey: keypair.public,
-          );
-
-          if (completeSig != null) {
-            await ExplorerService().sendV2WithdrawalCompleteTx(
-              hash: completePrepared['Hash'] as String,
-              signature: completeSig,
-              publicKey: keypair.public,
-            );
-          }
-        }
-      } catch (e) {
-        // Type 28 TX failed but BTC was already sent — not critical
-        print('Warning: Failed to record withdrawal completion on VFX chain: $e');
-      }
+      final recorded = await recordV2WithdrawalCompletion(
+        scIdentifier: scIdentifier,
+        requestHash: requestHash,
+        btcTxHash: btcTxHash,
+        amount: withdrawalAmount,
+        btcDestination: btcDestination,
+      );
 
       return {
         'success': true,
         'btc_transaction_hash': btcTxHash,
+        'completion_recorded': recorded['success'] == true,
+        'completion_message': recorded['message'],
       };
     } catch (e) {
       return {'success': false, 'message': 'FROST signing failed: $e'};

--- a/lib/features/token/providers/web_token_actions_manager.dart
+++ b/lib/features/token/providers/web_token_actions_manager.dart
@@ -642,6 +642,9 @@ class WebTokenActionsManager {
         'btc_transaction_hash': alreadyBroadcast.btcTxHash,
         'completion_recorded': recorded['success'] == true,
         'completion_message': recorded['message'],
+        'completion_recoverable': true,
+        'withdrawal_amount': alreadyBroadcast.amount,
+        'btc_destination': alreadyBroadcast.btcDestination,
       };
     }
 
@@ -762,7 +765,9 @@ class WebTokenActionsManager {
 
       // Persist before attempting the completion TX. From here on the BTC is
       // gone, so a closed tab or a failed send must still be recoverable.
-      PendingWithdrawalCompletionService().record(
+      // A failed write is not recoverable later, so it is reported rather than
+      // swallowed — the caller has to keep the user on this screen.
+      final persisted = PendingWithdrawalCompletionService().record(
         PendingWithdrawalCompletion(
           scIdentifier: scIdentifier,
           requestHash: requestHash,
@@ -788,6 +793,13 @@ class WebTokenActionsManager {
         'btc_transaction_hash': btcTxHash,
         'completion_recorded': recorded['success'] == true,
         'completion_message': recorded['message'],
+        // False means no durable record exists, so this withdrawal cannot be
+        // resumed in a later session.
+        'completion_recoverable': persisted,
+        // Returned so a retry can be driven from memory rather than from
+        // storage, which may be exactly what failed.
+        'withdrawal_amount': withdrawalAmount,
+        'btc_destination': btcDestination,
       };
     } catch (e) {
       return {'success': false, 'message': 'FROST signing failed: $e'};

--- a/test/features/btc_web/pending_withdrawal_completion_service_test.dart
+++ b/test/features/btc_web/pending_withdrawal_completion_service_test.dart
@@ -48,6 +48,14 @@ class _FakeStorage extends Storage {
   void setStringList(String key, List<String> value) => _data[key] = value;
 }
 
+/// Storage whose writes fail, standing in for a full or unavailable quota.
+class _UnwritableStorage extends _FakeStorage {
+  @override
+  void setMap(String key, Map<String, dynamic> value) {
+    throw StateError('storage unavailable');
+  }
+}
+
 PendingWithdrawalCompletion _entry({
   String requestHash = 'req-1',
   String btcTxHash = 'btc-1',
@@ -169,6 +177,22 @@ void main() {
 
       expect(service.forAddress('RMine').map((e) => e.requestHash), ['mine']);
       expect(service.forAddress(null), isEmpty);
+    });
+
+    test('record reports success when the write lands', () {
+      expect(service.record(_entry()), isTrue);
+    });
+
+    test('record reports failure instead of swallowing a write error', () async {
+      await singleton.reset();
+      singleton.registerSingleton<Storage>(_UnwritableStorage());
+      final failing = PendingWithdrawalCompletionService();
+
+      // Must be false: the caller has to know there is no durable reference to
+      // the broadcast BTC, otherwise a later resume re-runs FROST against
+      // spent inputs or reports an unsettled withdrawal as complete.
+      expect(failing.record(_entry()), isFalse);
+      expect(failing.get('req-1'), isNull);
     });
 
     test('a malformed entry does not hide the valid ones', () {

--- a/test/features/btc_web/pending_withdrawal_completion_service_test.dart
+++ b/test/features/btc_web/pending_withdrawal_completion_service_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rbx_wallet/core/singletons.dart';
+import 'package:rbx_wallet/core/storage.dart';
+import 'package:rbx_wallet/features/btc_web/models/btc_web_vbtc_token.dart';
+import 'package:rbx_wallet/features/btc_web/services/pending_withdrawal_completion_service.dart';
+
+/// In-memory [Storage] so the service can be exercised without Hive or
+/// SharedPreferences.
+class _FakeStorage extends Storage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  Future<void> init() async {
+    isInitialized = true;
+  }
+
+  @override
+  void remove(String key) => _data.remove(key);
+
+  @override
+  String? getString(String key) => _data[key];
+  @override
+  void setString(String key, String value) => _data[key] = value;
+
+  @override
+  bool? getBool(String key) => _data[key];
+  @override
+  void setBool(String key, bool value) => _data[key] = value;
+
+  @override
+  int? getInt(String key) => _data[key];
+  @override
+  void setInt(String key, int value) => _data[key] = value;
+
+  @override
+  Map<String, dynamic>? getMap(String key) => _data[key];
+  @override
+  void setMap(String key, Map<String, dynamic> value) => _data[key] = value;
+
+  @override
+  List<dynamic>? getList(String key) => _data[key];
+  @override
+  void setList(String key, List<dynamic> value) => _data[key] = value;
+
+  @override
+  List<String>? getStringList(String key) => _data[key];
+  @override
+  void setStringList(String key, List<String> value) => _data[key] = value;
+}
+
+PendingWithdrawalCompletion _entry({
+  String requestHash = 'req-1',
+  String btcTxHash = 'btc-1',
+  String fromAddress = 'RAddress1',
+  double amount = 0.5,
+  DateTime? createdAt,
+}) {
+  return PendingWithdrawalCompletion(
+    scIdentifier: 'sc-1',
+    requestHash: requestHash,
+    btcTxHash: btcTxHash,
+    amount: amount,
+    btcDestination: 'bc1qdestination',
+    fromAddress: fromAddress,
+    createdAt: createdAt ?? DateTime(2026, 7, 31, 12),
+  );
+}
+
+void main() {
+  late PendingWithdrawalCompletionService service;
+
+  setUp(() async {
+    await singleton.reset();
+    singleton.registerSingleton<Storage>(_FakeStorage());
+    service = PendingWithdrawalCompletionService();
+  });
+
+  group('withdrawalIsResumable', () {
+    test('accepts both spellings the API has used', () {
+      expect(withdrawalIsResumable({'status': 'pending'}), isTrue);
+      expect(withdrawalIsResumable({'status': 'requested'}), isTrue);
+    });
+
+    test('rejects settled and unknown states', () {
+      expect(withdrawalIsResumable({'status': 'completed'}), isFalse);
+      expect(withdrawalIsResumable({'status': 'cancelled'}), isFalse);
+      expect(withdrawalIsResumable({}), isFalse);
+    });
+  });
+
+  group('PendingWithdrawalCompletion', () {
+    test('survives a JSON round trip', () {
+      final original = _entry();
+      final restored =
+          PendingWithdrawalCompletion.fromJson(original.toJson());
+
+      expect(restored.scIdentifier, original.scIdentifier);
+      expect(restored.requestHash, original.requestHash);
+      expect(restored.btcTxHash, original.btcTxHash);
+      expect(restored.amount, original.amount);
+      expect(restored.btcDestination, original.btcDestination);
+      expect(restored.fromAddress, original.fromAddress);
+      expect(restored.createdAt, original.createdAt);
+    });
+
+    test('tolerates an integer amount from storage', () {
+      final restored = PendingWithdrawalCompletion.fromJson({
+        'sc_identifier': 'sc-1',
+        'request_hash': 'req-1',
+        'btc_tx_hash': 'btc-1',
+        'amount': 2,
+        'btc_destination': 'bc1q',
+        'from_address': 'RAddress1',
+        'created_at': '2026-07-31T12:00:00.000',
+      });
+
+      expect(restored.amount, 2.0);
+    });
+  });
+
+  group('PendingWithdrawalCompletionService', () {
+    test('returns null for a hash that was never recorded', () {
+      expect(service.get('nope'), isNull);
+    });
+
+    test('records and reads back a broadcast BTC transaction', () {
+      service.record(_entry());
+
+      final stored = service.get('req-1');
+      expect(stored, isNotNull);
+      expect(stored!.btcTxHash, 'btc-1');
+      expect(stored.amount, 0.5);
+    });
+
+    test('clear removes only the settled request', () {
+      service.record(_entry(requestHash: 'req-1'));
+      service.record(_entry(requestHash: 'req-2', btcTxHash: 'btc-2'));
+
+      service.clear('req-1');
+
+      expect(service.get('req-1'), isNull);
+      expect(service.get('req-2'), isNotNull);
+    });
+
+    test('re-recording the same hash overwrites rather than duplicates', () {
+      service.record(_entry(btcTxHash: 'btc-old'));
+      service.record(_entry(btcTxHash: 'btc-new'));
+
+      expect(service.all().length, 1);
+      expect(service.get('req-1')!.btcTxHash, 'btc-new');
+    });
+
+    test('all() returns newest first', () {
+      service.record(_entry(
+        requestHash: 'older',
+        createdAt: DateTime(2026, 7, 30),
+      ));
+      service.record(_entry(
+        requestHash: 'newer',
+        createdAt: DateTime(2026, 7, 31),
+      ));
+
+      expect(service.all().map((e) => e.requestHash), ['newer', 'older']);
+    });
+
+    test('forAddress filters to the signing wallet', () {
+      service.record(_entry(requestHash: 'mine', fromAddress: 'RMine'));
+      service.record(_entry(requestHash: 'theirs', fromAddress: 'RTheirs'));
+
+      expect(service.forAddress('RMine').map((e) => e.requestHash), ['mine']);
+      expect(service.forAddress(null), isEmpty);
+    });
+
+    test('a malformed entry does not hide the valid ones', () {
+      singleton<Storage>().setMap(
+        Storage.PENDING_VBTC_WITHDRAWAL_COMPLETIONS,
+        {
+          'broken': 'not-a-map',
+          'req-1': _entry().toJson(),
+        },
+      );
+
+      final all = service.all();
+      expect(all.length, 1);
+      expect(all.first.requestHash, 'req-1');
+    });
+  });
+}

--- a/web/index.html
+++ b/web/index.html
@@ -89,7 +89,7 @@
       }
       scriptLoaded = true;
       var scriptTag = document.createElement("script");
-      scriptTag.src = "main.dart.js?version=6.0.5";
+      scriptTag.src = "main.dart.js?version=6.0.6";
       scriptTag.type = "application/javascript";
       document.body.append(scriptTag);
     }


### PR DESCRIPTION
## Why

The Type 28 completion TX is what settles a vBTC v2 withdrawal on the VFX chain. On the web wallet it was best-effort: a failed prepare, a null signature, a rejected send, or any throw all fell through to a `print` warning while `completeV2Withdrawal` still returned success. The BTC left the vault, the contract stayed pending, and the dialog said "completed successfully" — with nothing in the UI or logs to reveal it.

## Web wallet / raw (`4c73bb2c`)

- Extracted `recordV2WithdrawalCompletion`, which checks the prepare result, the signature, **and** the send response, and reports success explicitly.
- `completeV2Withdrawal` now returns `completion_recorded`, so "BTC sent but not settled" can never render as unqualified success. The dialog surfaces it as its own state with a retry that re-sends only the Type 28 — never the Bitcoin TX.
- Persists `requestHash → btcTxHash` before attempting the completion, so a closed tab is recoverable instead of losing the fact that coins moved. Resuming a request that already has a stored broadcast skips FROST entirely rather than signing against spent inputs.
- A broadcast that returns no txid gets its own terminal state. Previously the unchecked `as String` cast threw into the FROST catch, reporting a spent-BTC withdrawal as a signing failure and offering a retry.
- Accepts both `'pending'` and `'requested'` as resumable. The Withdraw button only matched `'pending'`, so a `'requested'` withdrawal sent users into filing a duplicate request with no route to completion.
- Records the completion as a pending `TxType` 28 (defined but previously unused), and hides Cancel once the BTC is out.

## Desktop (`63d05632`)

`completeWithdrawal` used a 120s client timeout while the same FROST ceremony is budgeted 180s on web. A slow but successful signing surfaced as "Withdrawal Failed" with a Retry that calls CompleteWithdrawal again — potentially a second Bitcoin transaction.

- Timeout raised to 180s; client-side timeouts are now flagged on `WithdrawalResult` so they are distinguishable from a CLI rejection.
- On timeout the dialog polls the contract via `isWithdrawalStillActive` for up to 2 minutes before concluding. If the request stops being active, the CLI finished after we gave up and it reports success. Only a still-pending request fails, with copy warning that retrying can double-send.
- Retry guarded against double taps; dropped the unused `withdraw()` helper.

## Testing

`flutter analyze` is clean — no errors or warnings, and no new lints in any touched file. 11 new unit tests cover `PendingWithdrawalCompletionService` and the shared resumable-status logic.

Not verified against a live backend: a real FROST timeout, a rejected completion TX, and the desktop verification poll were checked by analyzer and reasoning only.

## Two things for reviewers

1. **Assumption to confirm:** `sendV2WithdrawalCompleteTx` is now checked for `success == true`, inferred from its sibling send endpoints since the old code discarded the response entirely. If `/withdraw/complete/tx/send/` returns a different shape, completions will show "Action Required" despite landing — noisy, not dangerous.
2. **Residual gap:** recovery records are local to the browser profile, so starting a withdrawal in one browser and returning in another still falls back to re-running FROST. Closing that needs `btc_transaction_hash` exposed on the `withdrawal_requests` entries — which would also be a better source than local storage once it exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hDDTnjYyEQYuteSYnw6uo
