### PR TITLE
fix(vbtc-v2): withdrawal safety, address validation, and tx-type coverage

### DIFF
--- a/lib/core/storage.dart
+++ b/lib/core/storage.dart
@@ -54,7 +54,14 @@ abstract class Storage {
   void setInt(String key, int value);
 
   Map<String, dynamic>? getMap(String key);
-  void setMap(String key, Map<String, dynamic> value);
+
+  /// Persists [value] under [key].
+  ///
+  /// The returned future completes only once the write has actually landed.
+  /// Backends reject asynchronously — IndexedDB in particular fails a quota or
+  /// private-browsing write after the call returns — so callers that need to
+  /// know the value is durable must await this and handle the error.
+  Future<void> setMap(String key, Map<String, dynamic> value);
 
   List<dynamic>? getList(String key);
   void setList(String key, List<dynamic> value);
@@ -114,9 +121,12 @@ class StorageImplementation extends Storage {
   }
 
   @override
-  void setMap(String key, Map<String, dynamic> value) {
+  Future<void> setMap(String key, Map<String, dynamic> value) async {
     final str = jsonEncode(value);
-    _instance.setString(_buildKey(key), str);
+    final didWrite = await _instance.setString(_buildKey(key), str);
+    if (!didWrite) {
+      throw StateError("Shared preferences refused the write for '$key'.");
+    }
   }
 
   @override
@@ -200,8 +210,8 @@ class StorageWebImplementation extends Storage {
   }
 
   @override
-  void setMap(String key, Map<String, dynamic> value) {
-    _instance.put(_buildKey(key), value);
+  Future<void> setMap(String key, Map<String, dynamic> value) {
+    return _instance.put(_buildKey(key), value);
   }
 
   @override

--- a/lib/core/storage.dart
+++ b/lib/core/storage.dart
@@ -39,6 +39,8 @@ abstract class Storage {
   static const BUTTERFLY_LINKS = "BUTTERFLY_LINKS";
   static const PENDING_VBTC_WITHDRAWAL_COMPLETIONS =
       "PENDING_VBTC_WITHDRAWAL_COMPLETIONS";
+  static const PENDING_VBTC_FROST_SIGNING_JOBS =
+      "PENDING_VBTC_FROST_SIGNING_JOBS";
   bool isInitialized = false;
 
   Future<void> init();

--- a/lib/features/btc/components/tokenized_btc_action_buttons.dart
+++ b/lib/features/btc/components/tokenized_btc_action_buttons.dart
@@ -1119,6 +1119,10 @@ class _TransferSharesModal extends BaseComponent {
             children: [
               TextFormField(
                 controller: toAddressController,
+                autovalidateMode: AutovalidateMode.onUserInteraction,
+                validator: forWithdrawl
+                    ? formValidatorBtcAddress
+                    : (value) => formValidatorNotEmpty(value, "Address"),
                 decoration: InputDecoration(
                   suffix: !forWithdrawl
                       ? AddressChoosingIconButton(
@@ -1271,8 +1275,13 @@ class _TransferSharesModal extends BaseComponent {
                         : AppColorVariant.Btc,
                     onPressed: () {
                       final toAddress = toAddressController.text.trim();
-                      if (toAddress.isEmpty) {
-                        print("Invalid To Address");
+                      // Checked here rather than through the enclosing Form,
+                      // which has no key and is never validated.
+                      final addressError = forWithdrawl
+                          ? formValidatorBtcAddress(toAddress)
+                          : formValidatorNotEmpty(toAddress, "Address");
+                      if (addressError != null) {
+                        Toast.error(addressError);
                         return;
                       }
 

--- a/lib/features/btc/components/tokenized_btc_action_buttons.dart
+++ b/lib/features/btc/components/tokenized_btc_action_buttons.dart
@@ -402,7 +402,9 @@ class TokenizedBtcActionButtons extends BaseComponent {
                 // V2: refresh token data and check for pending withdrawal before showing the form
                 if (token.version >= 2) {
                   // Fetch fresh V2 contract data to get current withdrawal state
-                  final freshContracts = await VbtcV2Service().getContractList();
+                  final freshContracts = await VbtcV2Service().getContractList(
+                    address: ref.read(sessionProvider).currentWallet?.address,
+                  );
                   final freshToken = freshContracts.firstWhereOrNull(
                     (t) => t.smartContractUid == token.smartContractUid,
                   );

--- a/lib/features/btc/components/withdrawal_processing_dialog.dart
+++ b/lib/features/btc/components/withdrawal_processing_dialog.dart
@@ -162,8 +162,9 @@ class _WithdrawalProcessingDialogState extends State<WithdrawalProcessingDialog>
     });
   }
 
-  /// Polls the contract until the request stops being the active withdrawal,
-  /// which means the CLI finished after our request timed out.
+  /// Polls the contract until this request shows up as settled, which means
+  /// the CLI finished after our request timed out. Anything short of that —
+  /// including a state the contract cannot account for — keeps polling.
   Future<void> _verifyWithdrawalSettled() async {
     debugPrint('$_tag Request timed out — verifying contract state for ${widget.requestHash}');
     setState(() => _state = _DialogState.verifying);
@@ -186,7 +187,7 @@ class _WithdrawalProcessingDialogState extends State<WithdrawalProcessingDialog>
           _result = WithdrawalResult(
             success: true,
             requestHash: widget.requestHash,
-            message: "Withdrawal completed. It is no longer pending on the contract.",
+            message: "Withdrawal completed. The contract has recorded it as settled.",
           );
           _state = _DialogState.success;
         });
@@ -201,7 +202,7 @@ class _WithdrawalProcessingDialogState extends State<WithdrawalProcessingDialog>
       _result = WithdrawalResult(
         success: false,
         requestHash: widget.requestHash,
-        message: "The signing ceremony timed out and the withdrawal is still pending on the contract. "
+        message: "The signing ceremony timed out and the withdrawal has not been recorded as settled. "
             "It may yet complete on its own — re-check the token before retrying, as retrying can "
             "broadcast a second Bitcoin transaction.",
       );

--- a/lib/features/btc/providers/tokenized_bitcoin_list_provider.dart
+++ b/lib/features/btc/providers/tokenized_bitcoin_list_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/providers/session_provider.dart';
 import '../models/tokenized_bitcoin.dart';
 import '../services/btc_service.dart';
 import '../services/vbtc_v2_service.dart';
@@ -11,9 +12,13 @@ class TokenizedBitcoinListProvider extends StateNotifier<List<TokenizedBitcoin>>
   }
 
   Future<void> load() async {
+    // The active wallet, not the contract owner: `myBalance` is this wallet's
+    // spendable figure, and V2 contracts are routinely held by non-owners.
+    final address = ref.read(sessionProvider).currentWallet?.address;
+
     final results = await Future.wait([
       BtcService().listTokenizedBitcoins(),
-      VbtcV2Service().getContractList(),
+      VbtcV2Service().getContractList(address: address),
     ]);
 
     state = [...results[0], ...results[1]];

--- a/lib/features/btc/screens/web_tokenize_btc_onboarding_steps.dart
+++ b/lib/features/btc/screens/web_tokenize_btc_onboarding_steps.dart
@@ -146,7 +146,10 @@ class _WebTransferBtcToVbtcStep extends BaseComponent {
                         return;
                       }
 
-                      if (amountParsed > (ref.read(webSessionProvider).btcBalanceInfo?.balance ?? 0)) {
+                      // btcBalance, not balance: the latter is satoshis, so
+                      // comparing a BTC amount against it lets a transfer of
+                      // up to 100,000,000x the actual balance through.
+                      if (amountParsed > (ref.read(webSessionProvider).btcBalanceInfo?.btcBalance ?? 0)) {
                         Toast.error("Not enough balance in BTC account to send $amountParsed BTC");
                         return;
                       }

--- a/lib/features/btc/services/vbtc_v2_service.dart
+++ b/lib/features/btc/services/vbtc_v2_service.dart
@@ -63,14 +63,22 @@ class VbtcV2Service extends BaseService {
       // GetContractList carries no per-address figure, so spendable balances
       // are fetched alongside it. One request per contract against the local
       // node.
-      final spendable = await Future.wait(
-        parsed.map(
-          (c) => getSpendableBalance(
-            address: address ?? c['OwnerAddress'] ?? c['RBXAddress'] ?? '',
-            scUid: c['SmartContractUID'] ?? c['SmartContractUid'] ?? '',
-          ),
-        ),
-      );
+      //
+      // Only ever for the address the caller named. Falling back to the
+      // contract's OwnerAddress would put the OWNER's spendable figure in
+      // `myBalance`, which is the current wallet's field — the same wrong-holder
+      // balance this lookup exists to fix, just sourced differently. With no
+      // address there is nothing correct to show, so it stays 0.
+      final List<double?> spendable = address == null
+          ? List<double?>.filled(parsed.length, null)
+          : await Future.wait(
+              parsed.map(
+                (c) => getSpendableBalance(
+                  address: address,
+                  scUid: c['SmartContractUID'] ?? c['SmartContractUid'] ?? '',
+                ),
+              ),
+            );
 
       final List<TokenizedBitcoin> tokens = [];
       for (int i = 0; i < parsed.length; i++) {

--- a/lib/features/btc/services/vbtc_v2_service.dart
+++ b/lib/features/btc/services/vbtc_v2_service.dart
@@ -51,8 +51,30 @@ class VbtcV2Service extends BaseService {
         return [];
       }
 
-      final List<TokenizedBitcoin> tokens = [];
+      final List<Map<String, dynamic>> parsed = [];
       for (final c in rawList) {
+        try {
+          parsed.add(Map<String, dynamic>.from(c));
+        } catch (e) {
+          _log(method, 'Failed to parse V2 contract: $e');
+        }
+      }
+
+      // GetContractList carries no per-address figure, so spendable balances
+      // are fetched alongside it. One request per contract against the local
+      // node.
+      final spendable = await Future.wait(
+        parsed.map(
+          (c) => getSpendableBalance(
+            address: address ?? c['OwnerAddress'] ?? c['RBXAddress'] ?? '',
+            scUid: c['SmartContractUID'] ?? c['SmartContractUid'] ?? '',
+          ),
+        ),
+      );
+
+      final List<TokenizedBitcoin> tokens = [];
+      for (int i = 0; i < parsed.length; i++) {
+        final c = parsed[i];
         try {
           final token = TokenizedBitcoin(
             id: (c['Id'] ?? 0).toDouble(),
@@ -60,7 +82,10 @@ class VbtcV2Service extends BaseService {
             rbxAddress: c['OwnerAddress'] ?? c['RBXAddress'] ?? '',
             btcAddress: c['DepositAddress'],
             balance: (c['Balance'] ?? 0).toDouble(),
-            myBalance: (c['MyBalance'] ?? c['Balance'] ?? 0).toDouble(),
+            // 0 rather than the contract balance when the lookup failed:
+            // blocking a transfer is recoverable, offering a balance that is
+            // not there is not.
+            myBalance: spendable[i] ?? 0,
             tokenName: c['Name'] ?? c['TokenName'] ?? 'vBTC',
             tokenDescription: c['Description'] ?? c['TokenDescription'] ?? '',
             smartContractMainId: (c['SmartContractMainId'] ?? 0).toDouble(),
@@ -81,6 +106,52 @@ class VbtcV2Service extends BaseService {
     } catch (e, st) {
       _log(method, 'EXCEPTION: $e\n$st');
       return [];
+    }
+  }
+
+  /// What [address] can actually spend of [scUid], or null if it could not be
+  /// determined.
+  ///
+  /// `GetContractList` reports only `Balance` — the confirmed BTC sitting in
+  /// the contract's Taproot deposit address. That is a property of the
+  /// contract, not of any one holder: it ignores the owner's own vBTC ledger
+  /// entries, counts nothing for a non-owner who was transferred vBTC, and
+  /// includes amounts already committed to a withdrawal in flight.
+  /// `GetVBTCBalance` is the endpoint that resolves all three per address.
+  Future<double?> getSpendableBalance({
+    required String address,
+    required String scUid,
+  }) async {
+    const method = 'GetVBTCBalance';
+
+    if (address.isEmpty || scUid.isEmpty) {
+      _log(method, 'Skipped: address or scUid missing');
+      return null;
+    }
+
+    try {
+      final result = await getJson(
+        "/GetVBTCBalance/$address/$scUid",
+        cleanPath: false,
+      );
+
+      if (result['Success'] != true) {
+        _log(method, 'FAILED for $address / $scUid: ${result['Message']}');
+        return null;
+      }
+
+      // AvailableBalance is the total less anything locked in an incomplete
+      // withdrawal request for this address.
+      final available = (result['AvailableBalance'] as num?)?.toDouble();
+      if (available == null) {
+        _log(method, 'No AvailableBalance in response for $address / $scUid');
+        return null;
+      }
+
+      return available;
+    } catch (e, st) {
+      _log(method, 'EXCEPTION: $e\n$st');
+      return null;
     }
   }
 

--- a/lib/features/btc/services/vbtc_v2_service.dart
+++ b/lib/features/btc/services/vbtc_v2_service.dart
@@ -456,10 +456,17 @@ class VbtcV2Service extends BaseService {
         e.type == DioExceptionType.receiveTimeout;
   }
 
-  /// Whether [withdrawalRequestHash] is still the contract's active withdrawal.
+  /// Whether [withdrawalRequestHash] is still awaiting settlement.
   ///
-  /// Returns null when the contract state could not be read — callers must not
-  /// treat that as settled.
+  /// Returns null when this particular request's fate could not be
+  /// established — callers must not treat that as settled.
+  ///
+  /// `ActiveWithdrawalRequestHash` alone cannot answer this. It is a single
+  /// contract-wide slot that any holder's new request overwrites, and a
+  /// cancellation clears it outright, so finding some other hash there says
+  /// nothing about this one. Completion is the only event that records the
+  /// request hash per request, in `WithdrawalHistory`, so that is what a
+  /// "settled" verdict is built on.
   Future<bool?> isWithdrawalStillActive({
     required String scUid,
     required String withdrawalRequestHash,
@@ -467,18 +474,41 @@ class VbtcV2Service extends BaseService {
     const method = 'IsWithdrawalStillActive';
 
     try {
-      final contracts = await getContractList();
-      final match = contracts.where((c) => c.smartContractUid == scUid);
+      final result = await getJson(
+        "/GetContractDetails/$scUid",
+        cleanPath: false,
+      );
 
-      if (match.isEmpty) {
-        _log(method, 'Could not read contract state for scUid: $scUid');
+      if (result['Success'] != true || result['Contract'] == null) {
+        _log(method, 'Could not read contract state for scUid: $scUid — ${result['Message']}');
         return null;
       }
 
-      final active = match.first.activeWithdrawalRequestHash;
-      final stillActive = active != null && active.isNotEmpty && active == withdrawalRequestHash;
-      _log(method, 'active: $active | checking: $withdrawalRequestHash | stillActive: $stillActive');
-      return stillActive;
+      final contract = Map<String, dynamic>.from(result['Contract']);
+
+      final history = contract['WithdrawalHistory'];
+      if (history is List) {
+        final completed = history.any(
+          (h) => h is Map && h['RequestHash'] == withdrawalRequestHash,
+        );
+        if (completed) {
+          _log(method, 'Request $withdrawalRequestHash is in the withdrawal history — settled');
+          return false;
+        }
+      }
+
+      final active = contract['ActiveWithdrawalRequestHash'];
+      if (active is String && active == withdrawalRequestHash) {
+        _log(method, 'Request $withdrawalRequestHash is still the active withdrawal');
+        return true;
+      }
+
+      // Not completed and not the active request: it was cancelled, or another
+      // holder's request took the slot. Either way this cannot be called
+      // settled, and reporting it as such would tell the user a withdrawal
+      // finished when it did not.
+      _log(method, 'Fate of $withdrawalRequestHash is unknown — active slot holds: $active');
+      return null;
     } catch (e, st) {
       _log(method, 'EXCEPTION: $e\n$st');
       return null;

--- a/lib/features/btc/utils.dart
+++ b/lib/features/btc/utils.dart
@@ -7,6 +7,7 @@ import 'package:crypto/crypto.dart' show sha256;
 
 import '../../app.dart';
 import '../../core/app_constants.dart';
+import '../../core/env.dart';
 import 'models/btc_fee_rate_preset.dart';
 
 double satashisToBtc(int satashis) {
@@ -259,6 +260,26 @@ bool isBitcoinAddress(String input, {bool testnet = false}) {
   }
 
   return false;
+}
+
+/// Form validator for a Bitcoin destination address on whichever network the
+/// app is pointed at.
+///
+/// Worth validating at entry rather than trusting the backend: a vBTC V2
+/// withdrawal request is committed on chain before any Bitcoin moves, and a
+/// typo'd destination can only be undone by a 75% validator governance vote.
+String? formValidatorBtcAddress(String? value) {
+  if (value == null || value.trim().isEmpty) {
+    return "BTC address required.";
+  }
+
+  if (!isBitcoinAddress(value, testnet: Env.btcIsTestNet)) {
+    return Env.btcIsTestNet
+        ? "Invalid BTC address. A testnet address is required."
+        : "Invalid BTC address.";
+  }
+
+  return null;
 }
 
 /* ----------------------------- Bech32 helpers ----------------------------- */

--- a/lib/features/btc_web/components/web_btc_tokenized_action_buttons.dart
+++ b/lib/features/btc_web/components/web_btc_tokenized_action_buttons.dart
@@ -292,7 +292,7 @@ class WebTokenizedBtcActionButtons extends BaseComponent {
 
             final address = await PromptModal.show(
               title: 'BTC Address',
-              validator: (val) => formValidatorNotEmpty(val, "Address"),
+              validator: formValidatorBtcAddress,
               labelText: "Receiving BTC Address",
             );
             if (address == null) return;

--- a/lib/features/btc_web/components/web_v2_withdrawal_dialog.dart
+++ b/lib/features/btc_web/components/web_v2_withdrawal_dialog.dart
@@ -93,6 +93,10 @@ class _WebV2WithdrawalDialogState extends ConsumerState<WebV2WithdrawalDialog> {
   /// against spent inputs, so no retry is offered.
   bool _btcBroadcastUnconfirmed = false;
 
+  /// Set when the explorer says this withdrawal was already signed elsewhere.
+  /// Same reason to withhold retry: signing again can pay the withdrawal twice.
+  bool _signingAlreadyStarted = false;
+
   /// The broadcast this dialog is trying to settle, held in memory so a retry
   /// never depends on storage — which may be the thing that failed.
   PendingWithdrawalCompletion? _pendingCompletion;
@@ -244,6 +248,7 @@ class _WebV2WithdrawalDialogState extends ConsumerState<WebV2WithdrawalDialog> {
 
     setState(() {
       _btcBroadcastUnconfirmed = result?['btc_broadcast_unconfirmed'] == true;
+      _signingAlreadyStarted = result?['signing_already_started'] == true;
       _step = _DialogStep.failure;
       _errorMessage = result?['message'] ?? "FROST signing failed or timed out. The withdrawal may still complete — check back shortly.";
     });
@@ -548,9 +553,13 @@ class _WebV2WithdrawalDialogState extends ConsumerState<WebV2WithdrawalDialog> {
               variant: AppColorVariant.Light,
               onPressed: () => Navigator.of(context).pop(),
             ),
-            // No retry when the BTC broadcast succeeded without returning a
-            // txid — signing again would spend inputs that are already gone.
-            if (_requestHash != null && !_btcBroadcastUnconfirmed) ...[
+            // No retry when signing has already produced a Bitcoin transaction
+            // this session cannot account for — whether the broadcast returned
+            // no txid, or the explorer says another device signed it. Either
+            // way, signing again can send the Bitcoin twice.
+            if (_requestHash != null &&
+                !_btcBroadcastUnconfirmed &&
+                !_signingAlreadyStarted) ...[
               const SizedBox(width: 8),
               AppButton(
                 label: "Retry Signing",

--- a/lib/features/btc_web/models/btc_web_vbtc_token.dart
+++ b/lib/features/btc_web/models/btc_web_vbtc_token.dart
@@ -5,14 +5,27 @@ import '../../nft/models/web_nft.dart';
 part 'btc_web_vbtc_token.freezed.dart';
 part 'btc_web_vbtc_token.g.dart';
 
-/// Withdrawal request statuses that still need completing. The API has used
-/// both spellings, and treating only one as resumable strands the other in a
-/// state where the UI offers a fresh request instead of finishing the existing
-/// one.
-const kResumableWithdrawalStatuses = {'pending', 'requested'};
+/// Withdrawal request statuses that still need completing.
+///
+/// These are the explorer's values, not the CLI's: the web wallet reads
+/// `withdrawal_requests[].status` off `/btc/vbtc-v2/`, where
+/// `VbtcV2WithdrawalRequest.Status` is lowercase snake_case and the full set is
+/// `requested`, `pending_btc`, `completed`, `cancellation_requested`,
+/// `cancelled`. This mirrors the explorer's own `ACTIVE_STATUSES`.
+///
+/// `pending_btc` matters most: it is set once FROST has produced a signed
+/// Bitcoin transaction, which is exactly the state a user needs to be able to
+/// come back and finish. `cancellation_requested` is deliberately absent — a
+/// contested withdrawal must not be offered for resuming.
+const kResumableWithdrawalStatuses = {'requested', 'pending_btc'};
 
-bool withdrawalIsResumable(Map<String, dynamic> withdrawalRequest) =>
-    kResumableWithdrawalStatuses.contains(withdrawalRequest['status']);
+/// Read case-insensitively so a change of spelling upstream cannot silently
+/// make every withdrawal look settled.
+bool withdrawalIsResumable(Map<String, dynamic> withdrawalRequest) {
+  final status = withdrawalRequest['status'];
+  if (status is! String) return false;
+  return kResumableWithdrawalStatuses.contains(status.trim().toLowerCase());
+}
 
 @freezed
 class BtcWebVbtcToken with _$BtcWebVbtcToken {

--- a/lib/features/btc_web/screens/web_tokenized_btc_detail_screen.dart
+++ b/lib/features/btc_web/screens/web_tokenized_btc_detail_screen.dart
@@ -289,7 +289,7 @@ class WebTokenizedBtcDetailScreen extends BaseScreen {
                                             final manager = ref.read(webTokenActionsManager);
                                             await manager.cancelV2Withdrawal(
                                               scIdentifier: token.scIdentifier,
-                                              ownerAddress: token.ownerAddress,
+                                              requestorAddress: wr['requestor_address'] ?? '',
                                               requestHash: wr['request_transaction_hash'] ?? '',
                                             );
                                           }

--- a/lib/features/btc_web/services/frost_resume_guard.dart
+++ b/lib/features/btc_web/services/frost_resume_guard.dart
@@ -1,0 +1,60 @@
+/// What a vBTC V2 withdrawal may safely do next when nothing local records it.
+///
+/// The wallet normally answers this from browser storage — a recorded Bitcoin
+/// broadcast, or a stored FROST job id. Neither survives a different device or
+/// a cleared profile, and on that path the only remaining account of what has
+/// already happened is the explorer's withdrawal row.
+enum FrostResumeAction {
+  /// Nothing has been signed. A fresh signing ceremony is safe.
+  ceremony,
+
+  /// A signed Bitcoin transaction exists and the row names it, so the
+  /// withdrawal can be settled with the completion transaction alone.
+  completionOnly,
+
+  /// Signing has already run and nothing here can finish it. Re-signing would
+  /// risk a second payout, so the user has to be told rather than retried.
+  refuse,
+}
+
+/// Decides what a resume with no local recovery record may do, given the
+/// explorer's row for the withdrawal (null when it could not be read).
+///
+/// Treats a withdrawal as already signed if EITHER signal says so:
+///
+/// - `signed_at` is set — the explorer's direct record that FROST produced a
+///   broadcastable Bitcoin transaction. `signed_btc_tx_hex` is deliberately
+///   withheld from the payload, since anyone holding it can broadcast it, so
+///   this timestamp is the only evidence available to a client.
+/// - the status is `pending_btc` — what the explorer sets at that same moment.
+///
+/// Either alone is enough on purpose. Requiring both would fail open against an
+/// explorer that carries the status but not yet the field, and a missing
+/// `signed_at` is not evidence that nothing was signed. The cost of being
+/// wrong is asymmetric: a needless manual step versus paying a withdrawal
+/// twice.
+FrostResumeAction frostResumeActionFor(Map<String, dynamic>? withdrawalRequest) {
+  // An unreadable row teaches nothing. Every first-time withdrawal reaches
+  // this code with no local record, so refusing here would block the ordinary
+  // path on a transient explorer error.
+  if (withdrawalRequest == null) return FrostResumeAction.ceremony;
+
+  final status = withdrawalRequest['status'];
+  final normalisedStatus = status is String ? status.trim().toLowerCase() : '';
+
+  final signedAt = withdrawalRequest['signed_at'];
+  final hasSignedAt = signedAt is String && signedAt.trim().isNotEmpty;
+
+  if (!hasSignedAt && normalisedStatus != 'pending_btc') {
+    return FrostResumeAction.ceremony;
+  }
+
+  // Only reachable once the Type 28 completion has landed, which also moves
+  // the row to `completed` — but if a hash is there, settling beats refusing.
+  final btcTxHash = withdrawalRequest['btc_transaction_hash'];
+  if (btcTxHash is String && btcTxHash.trim().isNotEmpty) {
+    return FrostResumeAction.completionOnly;
+  }
+
+  return FrostResumeAction.refuse;
+}

--- a/lib/features/btc_web/services/pending_frost_signing_job_service.dart
+++ b/lib/features/btc_web/services/pending_frost_signing_job_service.dart
@@ -1,0 +1,109 @@
+import '../../../core/singletons.dart';
+import '../../../core/storage.dart';
+
+/// A FROST signing job that was started for a vBTC V2 withdrawal and has not
+/// produced a broadcastable Bitcoin transaction yet.
+///
+/// Signing is asynchronous: the API hands back a job id and the wallet polls it
+/// for up to three minutes. That id exists only in the tab that started the
+/// ceremony, so closing the tab loses the only handle on a signing run that may
+/// already have succeeded — leaving the withdrawal signed but unbroadcast,
+/// with the validators refusing to sign it again for 24 hours. Persisting the
+/// id lets a later session pick the same poll back up instead of asking for a
+/// ceremony that will be refused.
+class PendingFrostSigningJob {
+  final String scIdentifier;
+  final String requestHash;
+  final String jobId;
+  final double amount;
+  final String btcDestination;
+  final String fromAddress;
+  final DateTime createdAt;
+
+  const PendingFrostSigningJob({
+    required this.scIdentifier,
+    required this.requestHash,
+    required this.jobId,
+    required this.amount,
+    required this.btcDestination,
+    required this.fromAddress,
+    required this.createdAt,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'sc_identifier': scIdentifier,
+        'request_hash': requestHash,
+        'job_id': jobId,
+        'amount': amount,
+        'btc_destination': btcDestination,
+        'from_address': fromAddress,
+        'created_at': createdAt.toIso8601String(),
+      };
+
+  factory PendingFrostSigningJob.fromJson(Map<String, dynamic> json) {
+    return PendingFrostSigningJob(
+      scIdentifier: json['sc_identifier'] ?? '',
+      requestHash: json['request_hash'] ?? '',
+      jobId: json['job_id'] ?? '',
+      amount: (json['amount'] as num?)?.toDouble() ?? 0,
+      btcDestination: json['btc_destination'] ?? '',
+      fromAddress: json['from_address'] ?? '',
+      createdAt: DateTime.tryParse(json['created_at'] ?? '') ?? DateTime.now(),
+    );
+  }
+}
+
+class PendingFrostSigningJobService {
+  static const _key = Storage.PENDING_VBTC_FROST_SIGNING_JOBS;
+
+  Map<String, dynamic> _readRaw() {
+    try {
+      return singleton<Storage>().getMap(_key) ?? {};
+    } catch (e) {
+      print("Failed to read pending FROST signing jobs: $e");
+      return {};
+    }
+  }
+
+  Future<bool> _writeRaw(Map<String, dynamic> data) async {
+    try {
+      await singleton<Storage>().setMap(_key, data);
+      return true;
+    } catch (e) {
+      print("Failed to persist pending FROST signing jobs: $e");
+      return false;
+    }
+  }
+
+  /// Record [entry] before polling starts, so the job survives the tab.
+  ///
+  /// Returns false if the write did not land. A withdrawal signed under a job
+  /// id nobody kept cannot be resumed, so callers should tell the user to stay
+  /// on the page rather than treat the ceremony as recoverable.
+  Future<bool> record(PendingFrostSigningJob entry) {
+    final data = _readRaw();
+    data[entry.requestHash] = entry.toJson();
+    return _writeRaw(data);
+  }
+
+  PendingFrostSigningJob? get(String requestHash) {
+    final raw = _readRaw()[requestHash];
+    if (raw == null) return null;
+    try {
+      return PendingFrostSigningJob.fromJson(Map<String, dynamic>.from(raw));
+    } catch (e) {
+      print("Failed to parse pending FROST signing job: $e");
+      return null;
+    }
+  }
+
+  /// Drop the job once it can no longer tell us anything — the Bitcoin
+  /// transaction was broadcast, signing failed outright, or the API no longer
+  /// knows the id.
+  Future<void> clear(String requestHash) async {
+    final data = _readRaw();
+    if (data.remove(requestHash) != null) {
+      await _writeRaw(data);
+    }
+  }
+}

--- a/lib/features/btc_web/services/pending_withdrawal_completion_service.dart
+++ b/lib/features/btc_web/services/pending_withdrawal_completion_service.dart
@@ -64,9 +64,12 @@ class PendingWithdrawalCompletionService {
     }
   }
 
-  bool _writeRaw(Map<String, dynamic> data) {
+  /// Awaits the write. Storage backends reject asynchronously — an IndexedDB
+  /// quota or private-browsing failure surfaces after `setMap` returns — so
+  /// without the await this reports success for a record that never landed.
+  Future<bool> _writeRaw(Map<String, dynamic> data) async {
     try {
-      singleton<Storage>().setMap(_key, data);
+      await singleton<Storage>().setMap(_key, data);
       return true;
     } catch (e) {
       print("Failed to persist pending withdrawal completions: $e");
@@ -82,7 +85,7 @@ class PendingWithdrawalCompletionService {
   /// ignore that: without it there is no durable reference to the broadcast
   /// Bitcoin transaction, so the withdrawal cannot be recovered in a later
   /// session and must be finished — or at least surfaced — now.
-  bool record(PendingWithdrawalCompletion entry) {
+  Future<bool> record(PendingWithdrawalCompletion entry) {
     final data = _readRaw();
     data[entry.requestHash] = entry.toJson();
     return _writeRaw(data);
@@ -121,10 +124,10 @@ class PendingWithdrawalCompletionService {
   }
 
   /// Drop the record once the completion TX is on chain.
-  void clear(String requestHash) {
+  Future<void> clear(String requestHash) async {
     final data = _readRaw();
     if (data.remove(requestHash) != null) {
-      _writeRaw(data);
+      await _writeRaw(data);
     }
   }
 }

--- a/lib/features/token/providers/web_token_actions_manager.dart
+++ b/lib/features/token/providers/web_token_actions_manager.dart
@@ -15,6 +15,7 @@ import '../../../core/providers/web_session_provider.dart';
 import '../../../utils/toast.dart';
 import '../../../utils/validation.dart';
 import '../../btc_web/models/btc_web_vbtc_token.dart';
+import '../../btc_web/services/pending_frost_signing_job_service.dart';
 import '../../btc_web/services/pending_withdrawal_completion_service.dart';
 import '../../global_loader/global_loading_provider.dart';
 import '../../keygen/models/keypair.dart';
@@ -612,11 +613,41 @@ class WebTokenActionsManager {
     }
   }
 
+  /// Watches a FROST signing job until it produces a Bitcoin transaction,
+  /// fails outright, or outlives the poll budget.
+  Future<_FrostSigningPollResult> _pollFrostSigningJob(String jobId) async {
+    int notFoundCount = 0;
+    for (int i = 0; i < 36; i++) {
+      await Future.delayed(const Duration(seconds: 5));
+      try {
+        final status = await ExplorerService().getV2WithdrawalCompleteStatus(jobId);
+        if (status['status'] == 'complete') {
+          return _FrostSigningPollResult.signed(status['signed_btc_tx_hex'] as String?);
+        } else if (status['status'] == 'failed') {
+          return _FrostSigningPollResult.failed(status['message'] ?? 'FROST signing failed');
+        } else if (status['success'] == false) {
+          notFoundCount++;
+          // Job not registered yet (race) — tolerate a few misses, bail if persistent
+          if (notFoundCount > 6) {
+            return _FrostSigningPollResult.failed(status['message'] ?? 'FROST signing job not found');
+          }
+        } else {
+          notFoundCount = 0; // reset if we get a valid pending response
+        }
+      } catch (_) {
+        // transient error — keep polling
+      }
+    }
+    return _FrostSigningPollResult.timedOut();
+  }
+
   /// V2 withdrawal complete via prepare→sign two messages→execute→broadcast BTC.
   ///
   /// If a previous attempt already broadcast the Bitcoin transaction, this skips
   /// FROST entirely and only retries the completion TX — re-running the ceremony
-  /// would sign against already-spent inputs.
+  /// would sign against already-spent inputs. If a previous attempt got as far
+  /// as starting a signing job, this resumes polling that job rather than asking
+  /// for a second ceremony the validators would refuse.
   Future<Map<String, dynamic>?> completeV2Withdrawal({
     required String scIdentifier,
     required String requestHash,
@@ -629,6 +660,10 @@ class WebTokenActionsManager {
 
     final alreadyBroadcast = PendingWithdrawalCompletionService().get(requestHash);
     if (alreadyBroadcast != null) {
+      // The signing job cannot tell us anything the broadcast has not already
+      // settled, so drop it rather than leave it to be resumed later.
+      await PendingFrostSigningJobService().clear(requestHash);
+
       final recorded = await recordV2WithdrawalCompletion(
         scIdentifier: scIdentifier,
         requestHash: requestHash,
@@ -649,90 +684,117 @@ class WebTokenActionsManager {
     }
 
     try {
-      // Step 1: Prepare — get messages to sign + withdrawal params
-      final prepared = await ExplorerService().prepareV2WithdrawalComplete(
-        scIdentifier: scIdentifier,
-        withdrawalRequestHash: requestHash,
-        ownerAddress: keypair.address,
-      );
+      final String jobId;
+      final double withdrawalAmount;
+      final String btcDestination;
+      // True when the job id only exists in memory, so nothing can pick this
+      // signing run back up if the page goes away.
+      bool signingRecoverable = true;
 
-      if (prepared['success'] != true || prepared['StartMessage'] == null) {
-        return {'success': false, 'message': prepared['message'] ?? 'Failed to prepare FROST signing'};
-      }
+      // A job left over from an earlier attempt is resumed as-is. Starting a
+      // second ceremony for the same request is refused for 24 hours, so the
+      // stored id is the only way back to a signature that may already exist.
+      final pendingJob = PendingFrostSigningJobService().get(requestHash);
 
-      final startMessage = prepared['StartMessage'] as String;
-      final startTimestamp = prepared['StartTimestamp'] as int;
-      final shareMessage = prepared['ShareDistributionMessage'] as String;
-      final shareTimestamp = prepared['ShareDistributionTimestamp'] as int;
-      final sessionId = prepared['SessionId'] as String;
-      final withdrawalAmount = (prepared['Amount'] as num?)?.toDouble() ?? 0;
-      final btcDestination = prepared['BTCDestination'] as String? ?? '';
+      if (pendingJob != null) {
+        jobId = pendingJob.jobId;
+        withdrawalAmount = pendingJob.amount;
+        btcDestination = pendingJob.btcDestination;
+      } else {
+        // Step 1: Prepare — get messages to sign + withdrawal params
+        final prepared = await ExplorerService().prepareV2WithdrawalComplete(
+          scIdentifier: scIdentifier,
+          withdrawalRequestHash: requestHash,
+          ownerAddress: keypair.address,
+        );
 
-      // Step 2: Sign both messages (same pattern as ceremony)
-      final startSig = await RawTransaction.getSignature(
-        message: startMessage,
-        privateKey: keypair.private,
-        publicKey: keypair.public,
-      );
+        if (prepared['success'] != true || prepared['StartMessage'] == null) {
+          return {'success': false, 'message': prepared['message'] ?? 'Failed to prepare FROST signing'};
+        }
 
-      final shareSig = await RawTransaction.getSignature(
-        message: shareMessage,
-        privateKey: keypair.private,
-        publicKey: keypair.public,
-      );
+        final startMessage = prepared['StartMessage'] as String;
+        final startTimestamp = prepared['StartTimestamp'] as int;
+        final shareMessage = prepared['ShareDistributionMessage'] as String;
+        final shareTimestamp = prepared['ShareDistributionTimestamp'] as int;
+        final sessionId = prepared['SessionId'] as String;
+        withdrawalAmount = (prepared['Amount'] as num?)?.toDouble() ?? 0;
+        btcDestination = prepared['BTCDestination'] as String? ?? '';
 
-      if (startSig == null || shareSig == null) {
-        return {'success': false, 'message': 'Failed to sign FROST messages'};
-      }
+        // Step 2: Sign both messages (same pattern as ceremony)
+        final startSig = await RawTransaction.getSignature(
+          message: startMessage,
+          privateKey: keypair.private,
+          publicKey: keypair.public,
+        );
 
-      // Step 3: Execute — kicks off FROST signing asynchronously, returns job_id
-      final executeResult = await ExplorerService().executeV2WithdrawalComplete(
-        scIdentifier: scIdentifier,
-        withdrawalRequestHash: requestHash,
-        ownerAddress: keypair.address,
-        sessionId: sessionId,
-        startSignature: startSig,
-        startTimestamp: startTimestamp,
-        shareDistributionSignature: shareSig,
-        shareDistributionTimestamp: shareTimestamp,
-        amount: withdrawalAmount,
-        btcDestination: btcDestination,
-        feeRate: prepared['FeeRate'] as int? ?? 0,
-      );
+        final shareSig = await RawTransaction.getSignature(
+          message: shareMessage,
+          privateKey: keypair.private,
+          publicKey: keypair.public,
+        );
 
-      final jobId = executeResult['job_id'] as String?;
-      if (jobId == null) {
-        return {'success': false, 'message': 'Failed to start FROST signing'};
+        if (startSig == null || shareSig == null) {
+          return {'success': false, 'message': 'Failed to sign FROST messages'};
+        }
+
+        // Step 3: Execute — kicks off FROST signing asynchronously, returns job_id
+        final executeResult = await ExplorerService().executeV2WithdrawalComplete(
+          scIdentifier: scIdentifier,
+          withdrawalRequestHash: requestHash,
+          ownerAddress: keypair.address,
+          sessionId: sessionId,
+          startSignature: startSig,
+          startTimestamp: startTimestamp,
+          shareDistributionSignature: shareSig,
+          shareDistributionTimestamp: shareTimestamp,
+          amount: withdrawalAmount,
+          btcDestination: btcDestination,
+          feeRate: prepared['FeeRate'] as int? ?? 0,
+        );
+
+        final startedJobId = executeResult['job_id'] as String?;
+        if (startedJobId == null) {
+          return {'success': false, 'message': 'Failed to start FROST signing'};
+        }
+        jobId = startedJobId;
+
+        // Persist before polling. From here the validators are signing, and a
+        // job id that only lives in this tab strands the withdrawal if the tab
+        // closes — a fresh ceremony would be refused for 24 hours.
+        signingRecoverable = await PendingFrostSigningJobService().record(
+          PendingFrostSigningJob(
+            scIdentifier: scIdentifier,
+            requestHash: requestHash,
+            jobId: jobId,
+            amount: withdrawalAmount,
+            btcDestination: btcDestination,
+            fromAddress: keypair.address,
+            createdAt: DateTime.now(),
+          ),
+        );
       }
 
       // Step 4: Poll for FROST signing result (up to 3 minutes)
-      String? signedBtcTxHex;
-      int notFoundCount = 0;
-      for (int i = 0; i < 36; i++) {
-        await Future.delayed(const Duration(seconds: 5));
-        try {
-          final status = await ExplorerService().getV2WithdrawalCompleteStatus(jobId);
-          if (status['status'] == 'complete') {
-            signedBtcTxHex = status['signed_btc_tx_hex'] as String?;
-            break;
-          } else if (status['status'] == 'failed') {
-            return {'success': false, 'message': status['message'] ?? 'FROST signing failed'};
-          } else if (status['success'] == false) {
-            notFoundCount++;
-            // Job not registered yet (race) — tolerate a few misses, bail if persistent
-            if (notFoundCount > 6) {
-              return {'success': false, 'message': status['message'] ?? 'FROST signing job not found'};
-            }
-          } else {
-            notFoundCount = 0; // reset if we get a valid pending response
-          }
-        } catch (_) {
-          // transient error — keep polling
-        }
+      final poll = await _pollFrostSigningJob(jobId);
+
+      if (poll.failureMessage != null) {
+        // Signing will not produce anything and the id is now worthless, so it
+        // must not be resumed — that would report a dead job forever.
+        await PendingFrostSigningJobService().clear(requestHash);
+        return {'success': false, 'message': poll.failureMessage};
       }
 
+      final signedBtcTxHex = poll.signedBtcTxHex;
       if (signedBtcTxHex == null || signedBtcTxHex.isEmpty) {
-        return {'success': false, 'message': 'FROST signing timed out. The withdrawal may still complete — check back shortly.'};
+        // The job is kept: signing may still land, and the stored id is what
+        // lets a later session collect the result.
+        return {
+          'success': false,
+          'signing_recoverable': signingRecoverable,
+          'message': signingRecoverable
+              ? 'FROST signing timed out. The withdrawal may still complete — reopen it from the token\'s withdrawal history to check.'
+              : 'FROST signing timed out and could not be saved for later recovery. Do not close this page — reopening will not be able to pick the signing back up.',
+        };
       }
 
       // Step 5: Broadcast the signed BTC TX
@@ -778,6 +840,11 @@ class WebTokenActionsManager {
           createdAt: DateTime.now(),
         ),
       );
+
+      // Signing is done and its output is on the Bitcoin network, so the job
+      // is finished with. Cleared after the broadcast record lands so the two
+      // are never both missing.
+      await PendingFrostSigningJobService().clear(requestHash);
 
       // Step 6: Record completion on VFX chain (Type 28 TX)
       final recorded = await recordV2WithdrawalCompletion(
@@ -948,3 +1015,25 @@ class WebTokenActionsManager {
 final webTokenActionsManager = Provider((ref) {
   return WebTokenActionsManager(ref);
 });
+
+/// How a FROST signing poll ended. The outcomes call for different handling of
+/// the stored job id: an outright failure finishes with it, a timeout does not
+/// — signing may still be running behind it.
+class _FrostSigningPollResult {
+  /// Set when signing finished and produced a Bitcoin transaction to broadcast.
+  final String? signedBtcTxHex;
+
+  /// Set when the job will never produce one — signing failed, or the API no
+  /// longer knows the id.
+  final String? failureMessage;
+
+  const _FrostSigningPollResult.signed(this.signedBtcTxHex)
+      : failureMessage = null;
+
+  const _FrostSigningPollResult.failed(this.failureMessage)
+      : signedBtcTxHex = null;
+
+  const _FrostSigningPollResult.timedOut()
+      : signedBtcTxHex = null,
+        failureMessage = null;
+}

--- a/lib/features/token/providers/web_token_actions_manager.dart
+++ b/lib/features/token/providers/web_token_actions_manager.dart
@@ -604,7 +604,7 @@ class WebTokenActionsManager {
         ),
       );
 
-      PendingWithdrawalCompletionService().clear(requestHash);
+      await PendingWithdrawalCompletionService().clear(requestHash);
 
       return {'success': true, 'hash': completionHash};
     } catch (e) {
@@ -767,7 +767,7 @@ class WebTokenActionsManager {
       // gone, so a closed tab or a failed send must still be recoverable.
       // A failed write is not recoverable later, so it is reported rather than
       // swallowed — the caller has to keep the user on this screen.
-      final persisted = PendingWithdrawalCompletionService().record(
+      final persisted = await PendingWithdrawalCompletionService().record(
         PendingWithdrawalCompletion(
           scIdentifier: scIdentifier,
           requestHash: requestHash,

--- a/lib/features/token/providers/web_token_actions_manager.dart
+++ b/lib/features/token/providers/web_token_actions_manager.dart
@@ -15,6 +15,7 @@ import '../../../core/providers/web_session_provider.dart';
 import '../../../utils/toast.dart';
 import '../../../utils/validation.dart';
 import '../../btc_web/models/btc_web_vbtc_token.dart';
+import '../../btc_web/services/frost_resume_guard.dart';
 import '../../btc_web/services/pending_frost_signing_job_service.dart';
 import '../../btc_web/services/pending_withdrawal_completion_service.dart';
 import '../../global_loader/global_loading_provider.dart';
@@ -613,6 +614,72 @@ class WebTokenActionsManager {
     }
   }
 
+  /// Asks the explorer whether signing has already run for [requestHash],
+  /// for the case where no local record survives to say so.
+  ///
+  /// Returns a result for the caller to hand straight back, or null to carry
+  /// on with a fresh ceremony. Only consulted once both local lookups have
+  /// missed — on the same browser the stored records are faster and better.
+  Future<Map<String, dynamic>?> _guardAgainstResigning({
+    required String scIdentifier,
+    required String requestHash,
+  }) async {
+    Map<String, dynamic>? row;
+
+    try {
+      final detail = await ExplorerService().getWebVbtcV2TokenDetail(scIdentifier);
+      for (final wr in detail.withdrawalRequests ?? <Map<String, dynamic>>[]) {
+        if (wr['request_transaction_hash'] == requestHash) {
+          row = wr;
+          break;
+        }
+      }
+    } catch (e) {
+      // Left null: see frostResumeActionFor, which reads an unreadable row as
+      // "carry on" so a transient explorer error cannot block a first-time
+      // withdrawal.
+      print("Could not read withdrawal state before signing: $e");
+    }
+
+    switch (frostResumeActionFor(row)) {
+      case FrostResumeAction.ceremony:
+        return null;
+
+      case FrostResumeAction.completionOnly:
+        final amount = (row!['amount'] as num?)?.toDouble() ?? 0;
+        final btcDestination = row['btc_address'] as String? ?? '';
+        final btcTxHash = row['btc_transaction_hash'] as String;
+
+        final recorded = await recordV2WithdrawalCompletion(
+          scIdentifier: scIdentifier,
+          requestHash: requestHash,
+          btcTxHash: btcTxHash,
+          amount: amount,
+          btcDestination: btcDestination,
+        );
+
+        return {
+          'success': true,
+          'btc_transaction_hash': btcTxHash,
+          'completion_recorded': recorded['success'] == true,
+          'completion_message': recorded['message'],
+          'completion_recoverable': true,
+          'withdrawal_amount': amount,
+          'btc_destination': btcDestination,
+        };
+
+      case FrostResumeAction.refuse:
+        return {
+          'success': false,
+          'signing_already_started': true,
+          'message': 'This withdrawal has already been signed, and the Bitcoin transaction '
+              'cannot be recovered from this browser. Do not start it again — signing a '
+              'second time can send the Bitcoin twice. Reopen the withdrawal in the browser '
+              'it was started from, or contact support so it can be settled manually.',
+        };
+    }
+  }
+
   /// Watches a FROST signing job until it produces a Bitcoin transaction,
   /// fails outright, or outlives the poll budget.
   Future<_FrostSigningPollResult> _pollFrostSigningJob(String jobId) async {
@@ -701,6 +768,15 @@ class WebTokenActionsManager {
         withdrawalAmount = pendingJob.amount;
         btcDestination = pendingJob.btcDestination;
       } else {
+        // Nothing local accounts for this withdrawal. Before asking for a
+        // ceremony, check whether one has already run somewhere this browser
+        // cannot see.
+        final alreadySigned = await _guardAgainstResigning(
+          scIdentifier: scIdentifier,
+          requestHash: requestHash,
+        );
+        if (alreadySigned != null) return alreadySigned;
+
         // Step 1: Prepare — get messages to sign + withdrawal params
         final prepared = await ExplorerService().prepareV2WithdrawalComplete(
           scIdentifier: scIdentifier,

--- a/lib/features/token/providers/web_token_actions_manager.dart
+++ b/lib/features/token/providers/web_token_actions_manager.dart
@@ -874,15 +874,21 @@ class WebTokenActionsManager {
   }
 
   /// V2 withdrawal cancel via prepare→sign→send.
+  ///
+  /// [requestorAddress] must be the address that made the withdrawal request,
+  /// not the token owner: the node rejects anyone else with "Only the original
+  /// requestor can cancel", and it builds the transaction from this address, so
+  /// it also has to match the key that signs. The explorer names the field
+  /// `owner_address` but forwards it as `RequestorAddress`.
   Future<bool> cancelV2Withdrawal({
     required String scIdentifier,
-    required String ownerAddress,
+    required String requestorAddress,
     required String requestHash,
   }) async {
     try {
       final prepared = await ExplorerService().prepareV2WithdrawalCancel(
         scIdentifier: scIdentifier,
-        ownerAddress: ownerAddress,
+        ownerAddress: requestorAddress,
         withdrawalRequestHash: requestHash,
       );
 
@@ -897,11 +903,11 @@ class WebTokenActionsManager {
       );
 
       if (result != null && result['success'] == true) {
-        ref.read(webTransactionListProvider(ownerAddress).notifier).insertPendingTx(
+        ref.read(webTransactionListProvider(requestorAddress).notifier).insertPendingTx(
           WebTransaction(
             hash: result['Hash'] ?? prepared['Hash'] ?? '',
-            toAddress: ownerAddress,
-            fromAddress: ownerAddress,
+            toAddress: requestorAddress,
+            fromAddress: requestorAddress,
             type: TxType.vbtcV2WithdrawalCancel,
             amount: 0,
             fee: 0,

--- a/lib/features/transactions/models/transaction.dart
+++ b/lib/features/transactions/models/transaction.dart
@@ -235,6 +235,8 @@ class Transaction with _$Transaction {
         return "Validator Registration";
       case 23:
         return "Validator Heartbeat";
+      case 24:
+        return "Validator Exit";
       case 25:
         return "vBTC Contract Mint";
       case 26:
@@ -284,6 +286,14 @@ class Transaction with _$Transaction {
         return "vBTC Bridge Lock";
       case 38:
         return "vBTC Bridge Unlock";
+      case 39:
+        return "vBTC Bridge Pool Unlock";
+      case 40:
+        return "vBTC Bridge Exit to BTC";
+      case 41:
+        return "vBTC Bridge Exit to BTC Complete";
+      case 42:
+        return "vBTC Bridge Exit to BTC Failed";
       default:
         return type.toString();
     }

--- a/lib/features/transactions/models/web_transaction.dart
+++ b/lib/features/transactions/models/web_transaction.dart
@@ -249,6 +249,8 @@ class WebTransaction with _$WebTransaction {
         return "Validator Registration";
       case 23:
         return "Validator Heartbeat";
+      case 24:
+        return "Validator Exit";
       case 25:
         return "vBTC Contract Mint";
       case 26:
@@ -277,6 +279,14 @@ class WebTransaction with _$WebTransaction {
         return "vBTC Bridge Lock";
       case 38:
         return "vBTC Bridge Unlock";
+      case 39:
+        return "vBTC Bridge Pool Unlock";
+      case 40:
+        return "vBTC Bridge Exit to BTC";
+      case 41:
+        return "vBTC Bridge Exit to BTC Complete";
+      case 42:
+        return "vBTC Bridge Exit to BTC Failed";
       default:
         return type.toString();
     }

--- a/test/features/btc/btc_address_validator_test.dart
+++ b/test/features/btc/btc_address_validator_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rbx_wallet/features/btc/utils.dart';
+
+/// The app defaults to mainnet in tests — `Env.btcIsTestNet` is driven by a
+/// compile-time define that is absent here — so these cover the mainnet rules
+/// the validator applies to a vBTC withdrawal destination.
+void main() {
+  group('formValidatorBtcAddress', () {
+    test('accepts a P2PKH address', () {
+      expect(
+        formValidatorBtcAddress('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'),
+        isNull,
+      );
+    });
+
+    test('accepts a P2SH address', () {
+      expect(
+        formValidatorBtcAddress('3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy'),
+        isNull,
+      );
+    });
+
+    test('accepts a bech32 SegWit v0 address', () {
+      expect(
+        formValidatorBtcAddress('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'),
+        isNull,
+      );
+    });
+
+    test('accepts a bech32m Taproot address', () {
+      expect(
+        formValidatorBtcAddress(
+            'bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0'),
+        isNull,
+      );
+    });
+
+    test('tolerates surrounding whitespace', () {
+      expect(
+        formValidatorBtcAddress(
+            '  bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4  '),
+        isNull,
+      );
+    });
+
+    test('rejects an empty or missing address', () {
+      expect(formValidatorBtcAddress(null), isNotNull);
+      expect(formValidatorBtcAddress(''), isNotNull);
+      expect(formValidatorBtcAddress('   '), isNotNull);
+    });
+
+    test('rejects a single mistyped character', () {
+      // The checksum is the whole point: a withdrawal request is committed on
+      // chain before any Bitcoin moves, so a typo can only be undone by a 75%
+      // validator vote.
+      expect(
+        formValidatorBtcAddress('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5'),
+        isNotNull,
+      );
+      expect(
+        formValidatorBtcAddress('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNb'),
+        isNotNull,
+      );
+    });
+
+    test('rejects a testnet address while pointed at mainnet', () {
+      expect(
+        formValidatorBtcAddress('tb1qw508d6qejxtdg4y5r3zarvaryvaxxpcs'),
+        isNotNull,
+      );
+    });
+
+    test('rejects a VFX address', () {
+      expect(
+        formValidatorBtcAddress('RNiQrW3aBUWZhfadqKxPuN46iGaR13ox7P'),
+        isNotNull,
+      );
+    });
+  });
+}

--- a/test/features/btc_web/frost_resume_guard_test.dart
+++ b/test/features/btc_web/frost_resume_guard_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rbx_wallet/features/btc_web/services/frost_resume_guard.dart';
+
+Map<String, dynamic> _row({
+  String status = 'requested',
+  String? signedAt,
+  String btcTransactionHash = '',
+}) {
+  return {
+    'id': 1,
+    'requestor_address': 'RAddress1',
+    'btc_address': 'bc1qdestination',
+    'amount': 0.25,
+    'fee_rate': 4.0,
+    'btc_transaction_hash': btcTransactionHash,
+    'status': status,
+    'signed_at': signedAt,
+    'request_transaction_hash': 'req-1',
+    'completion_transaction_hash': null,
+    'created_at': '2026-08-01T09:00:00Z',
+    'completed_at': null,
+  };
+}
+
+void main() {
+  group('frostResumeActionFor', () {
+    // The scenario the guard exists for. Nothing local survives — different
+    // device, or cleared storage — so the explorer's row is the only account
+    // of what already happened, and it says FROST produced a signed Bitcoin
+    // transaction. Starting another ceremony can pay the withdrawal twice.
+    test('never starts a ceremony for a signed withdrawal on a fresh device',
+        () {
+      final action = frostResumeActionFor(
+        _row(status: 'pending_btc', signedAt: '2026-08-01T09:04:12Z'),
+      );
+
+      expect(action, isNot(FrostResumeAction.ceremony));
+      expect(action, FrostResumeAction.refuse);
+    });
+
+    test('fails closed when pending_btc carries no signed_at', () {
+      // An explorer with the status but not yet the field. A missing timestamp
+      // is not evidence that nothing was signed, so this must not fall through
+      // to a ceremony.
+      expect(
+        frostResumeActionFor(_row(status: 'pending_btc')),
+        isNot(FrostResumeAction.ceremony),
+      );
+      expect(
+        frostResumeActionFor(_row(status: 'pending_btc', signedAt: '')),
+        isNot(FrostResumeAction.ceremony),
+      );
+      expect(
+        frostResumeActionFor({'status': 'pending_btc'}),
+        FrostResumeAction.refuse,
+      );
+    });
+
+    test('fails closed on signed_at alone, whatever the status says', () {
+      // Either signal is sufficient on its own: a row that was signed but
+      // whose status has not caught up must not be re-signed.
+      expect(
+        frostResumeActionFor(
+          _row(status: 'requested', signedAt: '2026-08-01T09:04:12Z'),
+        ),
+        FrostResumeAction.refuse,
+      );
+    });
+
+    test('reads the status case-insensitively', () {
+      expect(
+        frostResumeActionFor(_row(status: 'Pending_BTC')),
+        FrostResumeAction.refuse,
+      );
+      expect(
+        frostResumeActionFor(_row(status: ' pending_btc ')),
+        FrostResumeAction.refuse,
+      );
+    });
+
+    test('settles without signing when the row names the Bitcoin transaction',
+        () {
+      expect(
+        frostResumeActionFor(_row(
+          status: 'pending_btc',
+          signedAt: '2026-08-01T09:04:12Z',
+          btcTransactionHash: 'abc123',
+        )),
+        FrostResumeAction.completionOnly,
+      );
+    });
+
+    test('allows a ceremony for a request that has not been signed', () {
+      // The ordinary first-time path: the request is on chain, nothing local
+      // exists yet because nothing has happened yet.
+      expect(
+        frostResumeActionFor(_row(status: 'requested')),
+        FrostResumeAction.ceremony,
+      );
+    });
+
+    test('allows a ceremony when the row could not be read', () {
+      // Every first-time withdrawal arrives here with no local record, so a
+      // transient explorer failure must not block the ordinary path.
+      expect(frostResumeActionFor(null), FrostResumeAction.ceremony);
+    });
+
+    test('allows a ceremony for settled states and junk values', () {
+      expect(
+        frostResumeActionFor(_row(status: 'completed')),
+        FrostResumeAction.ceremony,
+      );
+      expect(
+        frostResumeActionFor(_row(status: 'cancelled')),
+        FrostResumeAction.ceremony,
+      );
+      expect(frostResumeActionFor({}), FrostResumeAction.ceremony);
+      expect(
+        frostResumeActionFor({'status': 7, 'signed_at': 7}),
+        FrostResumeAction.ceremony,
+      );
+    });
+  });
+}

--- a/test/features/btc_web/pending_frost_signing_job_service_test.dart
+++ b/test/features/btc_web/pending_frost_signing_job_service_test.dart
@@ -1,0 +1,182 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rbx_wallet/core/singletons.dart';
+import 'package:rbx_wallet/core/storage.dart';
+import 'package:rbx_wallet/features/btc_web/services/pending_frost_signing_job_service.dart';
+
+/// In-memory [Storage] so the service can be exercised without Hive or
+/// SharedPreferences.
+class _FakeStorage extends Storage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  Future<void> init() async {
+    isInitialized = true;
+  }
+
+  @override
+  void remove(String key) => _data.remove(key);
+
+  @override
+  String? getString(String key) => _data[key];
+  @override
+  void setString(String key, String value) => _data[key] = value;
+
+  @override
+  bool? getBool(String key) => _data[key];
+  @override
+  void setBool(String key, bool value) => _data[key] = value;
+
+  @override
+  int? getInt(String key) => _data[key];
+  @override
+  void setInt(String key, int value) => _data[key] = value;
+
+  @override
+  Map<String, dynamic>? getMap(String key) => _data[key];
+  @override
+  Future<void> setMap(String key, Map<String, dynamic> value) async =>
+      _data[key] = value;
+
+  @override
+  List<dynamic>? getList(String key) => _data[key];
+  @override
+  void setList(String key, List<dynamic> value) => _data[key] = value;
+
+  @override
+  List<String>? getStringList(String key) => _data[key];
+  @override
+  void setStringList(String key, List<String> value) => _data[key] = value;
+}
+
+/// Storage that accepts the call and rejects afterwards, which is how
+/// IndexedDB reports a quota or private-browsing failure.
+class _AsyncUnwritableStorage extends _FakeStorage {
+  @override
+  Future<void> setMap(String key, Map<String, dynamic> value) {
+    return Future.delayed(
+      const Duration(milliseconds: 1),
+      () => throw StateError('quota exceeded'),
+    );
+  }
+}
+
+PendingFrostSigningJob _job({
+  String requestHash = 'req-1',
+  String jobId = 'job-1',
+  double amount = 0.25,
+}) {
+  return PendingFrostSigningJob(
+    scIdentifier: 'sc-1',
+    requestHash: requestHash,
+    jobId: jobId,
+    amount: amount,
+    btcDestination: 'bc1qdestination',
+    fromAddress: 'RAddress1',
+    createdAt: DateTime(2026, 8, 1, 9),
+  );
+}
+
+void main() {
+  late PendingFrostSigningJobService service;
+
+  setUp(() async {
+    await singleton.reset();
+    singleton.registerSingleton<Storage>(_FakeStorage());
+    service = PendingFrostSigningJobService();
+  });
+
+  group('PendingFrostSigningJob', () {
+    test('survives a JSON round trip', () {
+      final original = _job();
+      final restored = PendingFrostSigningJob.fromJson(original.toJson());
+
+      expect(restored.scIdentifier, original.scIdentifier);
+      expect(restored.requestHash, original.requestHash);
+      expect(restored.jobId, original.jobId);
+      expect(restored.amount, original.amount);
+      expect(restored.btcDestination, original.btcDestination);
+      expect(restored.fromAddress, original.fromAddress);
+      expect(restored.createdAt, original.createdAt);
+    });
+
+    test('tolerates an integer amount from storage', () {
+      final restored = PendingFrostSigningJob.fromJson({
+        'sc_identifier': 'sc-1',
+        'request_hash': 'req-1',
+        'job_id': 'job-1',
+        'amount': 1,
+        'btc_destination': 'bc1q',
+        'from_address': 'RAddress1',
+        'created_at': '2026-08-01T09:00:00.000',
+      });
+
+      expect(restored.amount, 1.0);
+    });
+  });
+
+  group('PendingFrostSigningJobService', () {
+    test('returns null for a request with no signing job', () {
+      expect(service.get('nope'), isNull);
+    });
+
+    test('records the job id a resumed poll needs', () async {
+      await service.record(_job());
+
+      final stored = service.get('req-1');
+      expect(stored, isNotNull);
+      // Amount and destination come back too: a resumed poll settles the
+      // withdrawal without re-running prepare, which would start a second
+      // ceremony the validators refuse for 24 hours.
+      expect(stored!.jobId, 'job-1');
+      expect(stored.amount, 0.25);
+      expect(stored.btcDestination, 'bc1qdestination');
+    });
+
+    test('clear removes only the finished request', () async {
+      await service.record(_job(requestHash: 'req-1'));
+      await service.record(_job(requestHash: 'req-2', jobId: 'job-2'));
+
+      await service.clear('req-1');
+
+      expect(service.get('req-1'), isNull);
+      expect(service.get('req-2'), isNotNull);
+    });
+
+    test('re-recording the same hash overwrites rather than duplicates',
+        () async {
+      await service.record(_job(jobId: 'job-old'));
+      await service.record(_job(jobId: 'job-new'));
+
+      expect(service.get('req-1')!.jobId, 'job-new');
+    });
+
+    test('record reports success when the write lands', () async {
+      expect(await service.record(_job()), isTrue);
+    });
+
+    test('record reports failure when the write rejects asynchronously',
+        () async {
+      await singleton.reset();
+      singleton.registerSingleton<Storage>(_AsyncUnwritableStorage());
+      final failing = PendingFrostSigningJobService();
+
+      // Must be false: without a durable job id the caller has to keep the
+      // user on the page, because nothing can resume the signing poll.
+      expect(await failing.record(_job()), isFalse);
+      expect(failing.get('req-1'), isNull);
+    });
+
+    test('a malformed entry does not break the readable ones', () async {
+      await singleton<Storage>().setMap(
+        Storage.PENDING_VBTC_FROST_SIGNING_JOBS,
+        {
+          'broken': 'not-a-map',
+          'req-1': _job().toJson(),
+        },
+      );
+
+      expect(service.get('broken'), isNull);
+      expect(service.get('req-1')!.jobId, 'job-1');
+    });
+  });
+}

--- a/test/features/btc_web/pending_withdrawal_completion_service_test.dart
+++ b/test/features/btc_web/pending_withdrawal_completion_service_test.dart
@@ -98,15 +98,40 @@ void main() {
   });
 
   group('withdrawalIsResumable', () {
-    test('accepts both spellings the API has used', () {
-      expect(withdrawalIsResumable({'status': 'pending'}), isTrue);
+    test('accepts the explorer states that still need completing', () {
       expect(withdrawalIsResumable({'status': 'requested'}), isTrue);
+      // Signed by FROST but not settled on chain — the state the resume flow
+      // exists for.
+      expect(withdrawalIsResumable({'status': 'pending_btc'}), isTrue);
     });
 
-    test('rejects settled and unknown states', () {
+    test('rejects settled states', () {
       expect(withdrawalIsResumable({'status': 'completed'}), isFalse);
       expect(withdrawalIsResumable({'status': 'cancelled'}), isFalse);
+    });
+
+    test('rejects a contested withdrawal', () {
+      // Offering "tap to resume" on a withdrawal under a cancellation vote
+      // invites the user to push it through while it is being reversed.
+      expect(
+        withdrawalIsResumable({'status': 'cancellation_requested'}),
+        isFalse,
+      );
+    });
+
+    test('rejects unknown, missing and non-string states', () {
       expect(withdrawalIsResumable({}), isFalse);
+      expect(withdrawalIsResumable({'status': null}), isFalse);
+      expect(withdrawalIsResumable({'status': 3}), isFalse);
+      // Never emitted by any layer; it was in the set and matched nothing.
+      expect(withdrawalIsResumable({'status': 'pending'}), isFalse);
+    });
+
+    test('reads the status case-insensitively', () {
+      expect(withdrawalIsResumable({'status': 'Pending_BTC'}), isTrue);
+      expect(withdrawalIsResumable({'status': ' Requested '}), isTrue);
+      expect(withdrawalIsResumable({'status': 'Cancellation_Requested'}),
+          isFalse);
     });
   });
 

--- a/test/features/btc_web/pending_withdrawal_completion_service_test.dart
+++ b/test/features/btc_web/pending_withdrawal_completion_service_test.dart
@@ -35,7 +35,8 @@ class _FakeStorage extends Storage {
   @override
   Map<String, dynamic>? getMap(String key) => _data[key];
   @override
-  void setMap(String key, Map<String, dynamic> value) => _data[key] = value;
+  Future<void> setMap(String key, Map<String, dynamic> value) async =>
+      _data[key] = value;
 
   @override
   List<dynamic>? getList(String key) => _data[key];
@@ -48,11 +49,24 @@ class _FakeStorage extends Storage {
   void setStringList(String key, List<String> value) => _data[key] = value;
 }
 
-/// Storage whose writes fail, standing in for a full or unavailable quota.
+/// Storage that rejects the write synchronously.
 class _UnwritableStorage extends _FakeStorage {
   @override
-  void setMap(String key, Map<String, dynamic> value) {
+  Future<void> setMap(String key, Map<String, dynamic> value) {
     throw StateError('storage unavailable');
+  }
+}
+
+/// Storage that accepts the call and rejects afterwards, which is how
+/// IndexedDB reports a quota or private-browsing failure. Without an await on
+/// the write this rejection escapes unobserved and the record reads as saved.
+class _AsyncUnwritableStorage extends _FakeStorage {
+  @override
+  Future<void> setMap(String key, Map<String, dynamic> value) {
+    return Future.delayed(
+      const Duration(milliseconds: 1),
+      () => throw StateError('quota exceeded'),
+    );
   }
 }
 
@@ -131,8 +145,8 @@ void main() {
       expect(service.get('nope'), isNull);
     });
 
-    test('records and reads back a broadcast BTC transaction', () {
-      service.record(_entry());
+    test('records and reads back a broadcast BTC transaction', () async {
+      await service.record(_entry());
 
       final stored = service.get('req-1');
       expect(stored, isNotNull);
@@ -140,30 +154,31 @@ void main() {
       expect(stored.amount, 0.5);
     });
 
-    test('clear removes only the settled request', () {
-      service.record(_entry(requestHash: 'req-1'));
-      service.record(_entry(requestHash: 'req-2', btcTxHash: 'btc-2'));
+    test('clear removes only the settled request', () async {
+      await service.record(_entry(requestHash: 'req-1'));
+      await service.record(_entry(requestHash: 'req-2', btcTxHash: 'btc-2'));
 
-      service.clear('req-1');
+      await service.clear('req-1');
 
       expect(service.get('req-1'), isNull);
       expect(service.get('req-2'), isNotNull);
     });
 
-    test('re-recording the same hash overwrites rather than duplicates', () {
-      service.record(_entry(btcTxHash: 'btc-old'));
-      service.record(_entry(btcTxHash: 'btc-new'));
+    test('re-recording the same hash overwrites rather than duplicates',
+        () async {
+      await service.record(_entry(btcTxHash: 'btc-old'));
+      await service.record(_entry(btcTxHash: 'btc-new'));
 
       expect(service.all().length, 1);
       expect(service.get('req-1')!.btcTxHash, 'btc-new');
     });
 
-    test('all() returns newest first', () {
-      service.record(_entry(
+    test('all() returns newest first', () async {
+      await service.record(_entry(
         requestHash: 'older',
         createdAt: DateTime(2026, 7, 30),
       ));
-      service.record(_entry(
+      await service.record(_entry(
         requestHash: 'newer',
         createdAt: DateTime(2026, 7, 31),
       ));
@@ -171,16 +186,16 @@ void main() {
       expect(service.all().map((e) => e.requestHash), ['newer', 'older']);
     });
 
-    test('forAddress filters to the signing wallet', () {
-      service.record(_entry(requestHash: 'mine', fromAddress: 'RMine'));
-      service.record(_entry(requestHash: 'theirs', fromAddress: 'RTheirs'));
+    test('forAddress filters to the signing wallet', () async {
+      await service.record(_entry(requestHash: 'mine', fromAddress: 'RMine'));
+      await service.record(_entry(requestHash: 'theirs', fromAddress: 'RTheirs'));
 
       expect(service.forAddress('RMine').map((e) => e.requestHash), ['mine']);
       expect(service.forAddress(null), isEmpty);
     });
 
-    test('record reports success when the write lands', () {
-      expect(service.record(_entry()), isTrue);
+    test('record reports success when the write lands', () async {
+      expect(await service.record(_entry()), isTrue);
     });
 
     test('record reports failure instead of swallowing a write error', () async {
@@ -191,12 +206,22 @@ void main() {
       // Must be false: the caller has to know there is no durable reference to
       // the broadcast BTC, otherwise a later resume re-runs FROST against
       // spent inputs or reports an unsettled withdrawal as complete.
-      expect(failing.record(_entry()), isFalse);
+      expect(await failing.record(_entry()), isFalse);
       expect(failing.get('req-1'), isNull);
     });
 
-    test('a malformed entry does not hide the valid ones', () {
-      singleton<Storage>().setMap(
+    test('record reports failure when the write rejects asynchronously',
+        () async {
+      await singleton.reset();
+      singleton.registerSingleton<Storage>(_AsyncUnwritableStorage());
+      final failing = PendingWithdrawalCompletionService();
+
+      expect(await failing.record(_entry()), isFalse);
+      expect(failing.get('req-1'), isNull);
+    });
+
+    test('a malformed entry does not hide the valid ones', () async {
+      await singleton<Storage>().setMap(
         Storage.PENDING_VBTC_WITHDRAWAL_COMPLETIONS,
         {
           'broken': 'not-a-map',


### PR DESCRIPTION
Ten fixes from a cross-component audit of vBTC V2, one commit each so any single one can be dropped without unpicking the branch. Several are on the withdrawal path, where a wrong answer costs Bitcoin.

Ordinals, endpoint shapes and status strings below were checked against `Core-CLI` and the explorer rather than taken on trust; two findings came back different from how they were reported and are called out at the end.

| # | Fix | Applies to |
|---|-----|------------|
| 1 | Await the withdrawal recovery write | web |
| 2 | Persist the FROST signing job id | web |
| 3 | Validate the BTC destination | desktop + web |
| 4 | Per-address vBTC balance | desktop |
| 5 | Scope the settled check to one request | desktop |
| 6 | Cancel as the requestor | web |
| 7 | Unit mismatch in the tokenize step | web |
| 8 | Missing transaction type labels | desktop + web |
| 9 | Resumable withdrawal statuses | web |
| 10 | Refuse to re-sign a withdrawal signed elsewhere | web |

> **Merge order:** fixes 9 and 10 only do anything once **VerifiedX-SpyglassService#44** ships `pending_btc` and `signed_at` on the `/btc/vbtc-v2/` wire. Merged in the other order they are inert, not broken — no row can currently hold either value. Worth knowing when reviewing, and worth landing Spyglass first if the two are being sequenced.

---

### 1. Await the withdrawal recovery write — web

**Broken:** `StorageWebImplementation.setMap` called `Box.put()` and dropped the returned Future. IndexedDB rejects asynchronously, so a quota or private-browsing failure landed after the call returned and `PendingWithdrawalCompletionService.record` reported success for a record that was never written.

**Consequence:** that record is the only thing that stops a resumed withdrawal from re-running FROST against inputs the first Bitcoin broadcast already spent. The UI also told the user the withdrawal was safe to come back to when it was not.

**Changed:** `Storage.setMap` returns `Future<void>` and completes only once the write lands; the shared-preferences backend throws when it reports a refused write instead of returning silently. `_writeRaw` awaits it, so both a synchronous throw and an asynchronous rejection reach the caller. `record`/`clear` are async and their two call sites await. Added a test for an asynchronous rejection — the existing failure test only covered a synchronous throw, so it passed green while the write was being dropped.

### 2. Persist the FROST signing job id — web

**Broken:** the job id from `executeV2WithdrawalComplete` lived in a local variable for the ~180s poll.

**Consequence:** closing the tab lost the only handle on a ceremony that may already have produced a signed Bitcoin transaction. A second ceremony for the same request is refused for 24 hours, so the withdrawal was stranded signed-but-unbroadcast with no way back to the signature.

**Changed:** new `PendingFrostSigningJobService` stores the job id, amount and destination against the request hash, mirroring `PendingWithdrawalCompletionService`. The id is written *before* polling starts and a failed write is reported so the caller can tell the user to stay on the page. A stored job is resumed by polling it directly, skipping prepare/sign/execute. The record is dropped once it can say nothing more — BTC broadcast, signing failed outright, or the API no longer knows the id — and **kept** on timeout, which is the case the fix exists for. Polling moved to `_pollFrostSigningJob` so both paths share it; timings and tolerances are unchanged.

### 3. Validate the BTC destination on both withdrawal paths — desktop + web

**Broken:** neither withdrawal flow checked the destination address. The desktop field had no `validator:` at all and its submit handler only rejected an empty string; the web prompt used `formValidatorNotEmpty`.

**Consequence:** a typo went through to a Type 27 request. Once that is committed on chain the destination can only be changed by a 75% validator governance vote.

**Changed:** the repo already ships a correct Base58Check/bech32/bech32m validator with a `testnet` parameter (`lib/features/btc/utils.dart`), called from exactly one place. A `formValidatorBtcAddress` helper next to it wires it into both destinations, driven by `Env.btcIsTestNet` — the flag the surrounding BTC code already uses. On desktop it goes on the field *and* in the submit handler, because the enclosing `Form` has no key and is never validated; the transfer (non-withdrawal) case keeps its existing required-only rule. On web `PromptModal` already runs its validator before returning. Tests cover P2PKH, P2SH, bech32 v0 and bech32m Taproot destinations, a single mistyped character, and a testnet address on mainnet.

### 4. Per-address vBTC balance — desktop

**Broken:** `GetContractList` returns no `MyBalance` field, so `(c['MyBalance'] ?? c['Balance'] ?? 0)` always fell through to `Balance` — the confirmed BTC in the contract's Taproot deposit address.

**Consequence:** `Balance` is a property of the contract, not of a holder. It ignores the owner's own vBTC ledger entries, counts nothing for a non-owner who was transferred vBTC, and still includes amounts committed to a withdrawal in flight. The desktop UI uses `myBalance` as the transfer and withdrawal ceiling, so holders were shown a figure the node would not honour.

**Changed:** `GetVBTCBalance/{address}/{scUID}` is the endpoint that resolves this per address — deposit balance plus ledger for the owner, ledger alone for a non-owner, less any incomplete withdrawal. `getContractList` reads `AvailableBalance` from it for each contract in parallel, keyed on the address the row is attributed to. A failed lookup yields 0 rather than the contract balance: blocking a transfer is recoverable, offering a balance that is not there is not.

### 5. Scope the settled check to the request being verified — desktop

**Broken:** `isWithdrawalStillActive` answered a per-request question by reading `ActiveWithdrawalRequestHash`, a single contract-wide slot. Any holder's new request overwrites it (`StateData.cs:3275`) and an approved cancellation clears it (`StateData.cs:3586`).

**Consequence:** the timeout path added in 63d0563 reads a `false` from this as "Withdrawal completed". A concurrent request from another holder was enough to turn a failed withdrawal into a success message — the worst direction for this to be wrong in.

**Changed:** completion is the only event that records a hash per request, appending it to `WithdrawalHistory` (`StateData.cs:3352`). The check now reads `GetContractDetails/{scUID}` and returns `false` only when the request appears in that history, `true` while it is still the active request, and `null` otherwise — cancelled, or displaced by another holder. Callers already treat anything but `false` as unsettled, so the ambiguous case keeps polling and then reports failure with the existing do-not-retry warning. Dialog copy updated to match what is actually being established.

### 6. Cancel a withdrawal as the requestor, not the owner — web

**Broken:** the cancel button passed `token.ownerAddress`. The node checks `existingRequest.RequestorAddress != payload.RequestorAddress` and answers "Only the original requestor can cancel" (`VBTCController.cs:2481`).

**Consequence:** cancellation failed for every requestor who was not also the token owner — anyone holding vBTC transferred to them. Even reaching the chain it would have carried the wrong sender and nonce for the key that signs it, since the node builds the transaction's `FromAddress` from that address.

**Changed:** the withdrawal list is already filtered to the current wallet's own requests, so the requestor address is on the row being cancelled. The parameter is renamed `ownerAddress` → `requestorAddress` to stop the same substitution happening again; the explorer's field is named `owner_address` but forwarded as `RequestorAddress`, which is what invited it.

### 7. Compare the tokenization amount in matching units — web

**Broken:** the "Initiate Transfer" guard compared a BTC-denominated amount against `btcBalanceInfo.balance`, an `int` of satoshis. `BtcWebBalanceInfo` exposes `btcBalance` for the BTC value, and `send_form_provider` validates against that.

**Consequence:** the check passes for any amount up to 100,000,000x the real balance, so the guard let the transfer through to fail later against the actual UTXO set instead of saying so up front.

**Changed:** compare against `btcBalance`.

### 8. Label the transaction types that fell through to a number — desktop + web

**Broken:** both `typeLabel` switches covered 0-23 and 25-38 then returned `type.toString()`.

**Consequence:** five ordinals rendered in the transaction list as bare integers, including every bridge exit.

**Changed:** added 24 `VBTC_V2_VALIDATOR_EXIT`, 39 `VBTC_V2_BRIDGE_POOL_UNLOCK`, 40 `VBTC_V2_BRIDGE_EXIT_TO_BTC`, 41 `VBTC_V2_BRIDGE_EXIT_TO_BTC_COMPLETE`, 42 `VBTC_V2_BRIDGE_EXIT_TO_BTC_FAIL` to both models. Ordinals verified against `ReserveBlockCore/Models/Transaction.cs:85`; labels follow the naming already used by the neighbouring cases.

### 9. Match the resumable set to the statuses actually sent — web

**Broken:** `kResumableWithdrawalStatuses = {'pending', 'requested'}` matched on `'pending'`, which no layer emits.

**Consequence:** the string was inert, but the set was missing `pending_btc` — the status the explorer sets once FROST has produced a signed Bitcoin transaction, i.e. exactly the state a user is in when they close the tab mid-signing, and the state the resume flow exists for. Reading it as settled removes the "tap to resume" entry from the withdrawal history and offers a fresh request instead.

**Changed:** the set is now `{'requested', 'pending_btc'}`, mirroring the explorer's own `ACTIVE_STATUSES`. `cancellation_requested` stays out — a withdrawal under a cancellation vote must not be offered for pushing through. The status is read case-insensitively and non-strings are rejected, so a spelling change upstream cannot quietly make every withdrawal look settled.

### 10. Refuse to re-sign a withdrawal signed elsewhere — web

**Broken:** `completeV2Withdrawal` decided whether to run a FROST ceremony purely from browser storage — the recorded Bitcoin broadcast, then the stored job id from fix 2. Neither survives a different device or a cleared profile, so on that path both lookups miss and it starts a fresh ceremony.

**Consequence:** for a `requested` row that is correct. For one already signed it is a second Bitcoin payout, held off only by the node's 24h re-sign refusal — which expires. Fix 9 is what makes a `pending_btc` row tappable in the wallet, so the guard belongs alongside it rather than after it.

**Changed:** when — and only when — both local lookups have missed, the explorer's row is consulted. A withdrawal counts as already signed if **either** `signed_at` is set **or** the status is `pending_btc`. Either alone is sufficient on purpose: requiring both fails open against an explorer that carries the status but not yet the field, and an absent timestamp is not evidence that nothing was signed. The cost of being wrong is asymmetric — a needless manual step against paying a withdrawal twice.

- signed, and the row names the Bitcoin transaction → settle with the completion TX alone, never FROST
- signed, and it does not → refuse and say so; the dialog withholds "Retry Signing", as it already does for an unconfirmed broadcast
- not signed → unchanged, the ceremony runs
- row unreadable → unchanged. Every first-time withdrawal reaches this code with no local record, so a transient explorer error must not block the ordinary path

Gated on `signed_at`, not `signed_btc_tx_hex` — the explorer withholds the hex from the payload since anyone holding it can broadcast it. The local-storage paths are untouched: they are faster and better on the same browser, and this is strictly their fallback.

The decision is a pure function (`frostResumeActionFor`), so the cross-device case is covered head-on: no completion record, no job id, row is `pending_btc` with `signed_at` — asserted never to reach a ceremony.

---

## Two findings came back different from how they were reported

**The web wallet does not see the CLI's status names.** Finding 9 was framed against `VBTCWithdrawalStatus` in the node — `None`, `Requested`, `Pending_BTC`, `Completed`, `Cancelled`, `Cancellation_Requested`. The web wallet reads `withdrawal_requests[].status` from the explorer, not the node, and the explorer's `VbtcV2WithdrawalRequest.Status` is lowercase snake_case. Live mainnet and testnet `/btc/vbtc-v2/` return `"requested"` and `"completed"`. Matching on `Cancellation_Requested` would have been dead code.

**A contested withdrawal does not currently read as resumable.** The explorer's Type 29 handler sets the row straight to `cancelled`, so a cancellation request never surfaces as an in-between state on this wire today. `cancellation_requested` is nonetheless excluded from the resumable set, because the explorer declares it as a status and the wallet should not start resuming contested withdrawals the day it starts being written.

## Not fixed

- **`isVbtcTx` has the same gap as finding 8.** `transaction.dart` treats 25-30 and 37-38 as vBTC transactions but not 39-42, so the new bridge-exit types are labelled correctly and still filtered out of vBTC views. Left alone: it changes which transactions appear where, which is a product decision rather than a defect fix.
- **`TxType` in `app_constants.dart` stops at 38.** The switches use bare integers, matching the existing style, so nothing in this change needs the constants.
- **`Storage.setString`/`setBool`/`setInt`/`setList` still drop their write futures — deliberately out of scope here, and the top follow-up.** Fix 1 corrected `setMap` because that is what the withdrawal recovery record goes through. Its four siblings have the identical defect: the returned Future is discarded, so an asynchronous rejection is never observed and the caller reads a lost write as a success. That covers `Storage.WEB_KEYPAIR`, `WEB_RA_KEYPAIR` and `WEB_BTC_KEYPAIR` — the encrypted keypairs written by `web_session_provider` — where a silently dropped write means an unrecoverable wallet. Left out to keep fix 1 droppable and reviewable; it wants its own change.

## Verification

Toolchain: `fvm flutter` 3.7.12, the version pinned in `.fvmrc`. Plain `flutter` on this machine is 3.35.4, whose pub solver cannot resolve this pubspec (`intl ^0.17.0` vs `phone_form_field ^7.1.0`), so it cannot run the suite at all.

- `fvm flutter analyze` — 0 errors, 0 warnings. 351 info-level lints, unchanged from `main`.
- `fvm flutter test test/features` — 43 passed (13 before this branch).
- `fvm flutter test test/` — one failure, `widget_test.dart` "Counter increments smoke test". Pre-existing: it is the unmodified Flutter template test and fails on `main` too, verified by stashing this branch's changes.
- Commit 10 verified droppable in isolation: `git revert` applies cleanly and analysis stays at 0 errors without it.

Not exercised against a live node or a real withdrawal.
