### PR TITLE
fix(vbtc-v2-web): only offer a withdrawal to the account that requested it

### DIFF
--- a/lib/features/btc/components/tokenized_btc_action_buttons.dart
+++ b/lib/features/btc/components/tokenized_btc_action_buttons.dart
@@ -409,10 +409,16 @@ class TokenizedBtcActionButtons extends BaseComponent {
                     (t) => t.smartContractUid == token.smartContractUid,
                   );
 
+                  // NOTE: `hasPendingWithdrawal` comes from the contract's
+                  // ActiveWithdrawal* fields, which are a single slot shared by
+                  // every holder — GetContractList carries no requestor, so
+                  // this cannot be scoped to the current wallet the way the web
+                  // build scopes it. The copy therefore does not claim the
+                  // withdrawal belongs to this account.
                   if (freshToken != null && freshToken.hasPendingWithdrawal) {
                     final shouldComplete = await ConfirmDialog.show(
                       title: "Pending Withdrawal Found",
-                      body: "You have a pending withdrawal of ${freshToken.activeWithdrawalAmount} vBTC to ${freshToken.activeWithdrawalBtcDestination}.\n\nWould you like to complete it?",
+                      body: "This token has a pending withdrawal of ${freshToken.activeWithdrawalAmount} vBTC to ${freshToken.activeWithdrawalBtcDestination}.\n\nIt may have been requested by another holder of this token. Only the account that requested it can complete it.\n\nWould you like to try to complete it?",
                       confirmText: "Complete",
                       cancelText: "Dismiss",
                     );

--- a/lib/features/btc_web/components/web_btc_tokenized_action_buttons.dart
+++ b/lib/features/btc_web/components/web_btc_tokenized_action_buttons.dart
@@ -252,8 +252,11 @@ class WebTokenizedBtcActionButtons extends BaseComponent {
               return;
             }
 
-            // Check for pending withdrawal to resume
-            final pending = token.resumableWithdrawalRequests;
+            // Only this wallet's own outstanding withdrawals. Resuming
+            // another holder's makes the FROST leader address and the
+            // signature disagree, which validators reject — and the ceremony
+            // then hangs rather than failing.
+            final pending = token.resumableWithdrawalRequestsFor(myAddress);
             if (pending.isNotEmpty) {
               final requestHash = pending.first['request_transaction_hash'] as String?;
               if (requestHash != null) {

--- a/lib/features/btc_web/models/btc_web_vbtc_token.dart
+++ b/lib/features/btc_web/models/btc_web_vbtc_token.dart
@@ -53,8 +53,29 @@ class BtcWebVbtcToken with _$BtcWebVbtcToken {
 
   factory BtcWebVbtcToken.fromJson(Map<String, dynamic> json) => _$BtcWebVbtcTokenFromJson(json);
 
-  List<Map<String, dynamic>> get resumableWithdrawalRequests =>
-      (withdrawalRequests ?? []).where(withdrawalIsResumable).toList();
+  /// Outstanding withdrawals that `address` itself requested.
+  ///
+  /// Scoped to the requestor on purpose. A vBTC contract is shared — every
+  /// holder's withdrawals sit in the same list — and completing one signs the
+  /// FROST leader auth with whichever wallet is active. The node takes the
+  /// coordinator from the stored request's RequestorAddress, so acting on
+  /// somebody else's request makes the leader address and the signature
+  /// disagree, and every validator rejects the ceremony. It never starts, so
+  /// the caller sees a hang rather than an error.
+  ///
+  /// Returns nothing for a null address: with no wallet to compare against
+  /// there is no request this session can safely finish.
+  List<Map<String, dynamic>> resumableWithdrawalRequestsFor(String? address) {
+    if (address == null || address.isEmpty) return const [];
+    return (withdrawalRequests ?? [])
+        .where(withdrawalIsResumable)
+        .where((w) => w['requestor_address'] == address)
+        .toList();
+  }
+
+  /// True when `address` has a withdrawal of its own still to finish.
+  bool hasResumableWithdrawalFor(String? address) =>
+      resumableWithdrawalRequestsFor(address).isNotEmpty;
 
   double balanceForAddress(String? address) {
     if (address == null) {

--- a/lib/features/btc_web/screens/web_tokenized_btc_detail_screen.dart
+++ b/lib/features/btc_web/screens/web_tokenized_btc_detail_screen.dart
@@ -236,7 +236,15 @@ class WebTokenizedBtcDetailScreen extends BaseScreen {
                       final status = wr['status'] ?? 'unknown';
                       final amount = wr['amount'];
                       final btcAddr = wr['btc_address'] ?? '';
-                      final isRequested = withdrawalIsResumable(wr);
+                      // Resumable AND ours. The list shows every holder's
+                      // withdrawals because the contract is shared, but only
+                      // the wallet that made a request can finish it: the node
+                      // takes the FROST coordinator from the stored
+                      // RequestorAddress while the signature comes from the
+                      // active wallet, so acting on someone else's request
+                      // makes validators reject a ceremony that then hangs.
+                      final isMine = wr['requestor_address'] == address;
+                      final isRequested = withdrawalIsResumable(wr) && isMine;
                       final unrecorded = PendingWithdrawalCompletionService().get(
                         wr['request_transaction_hash'] ?? '',
                       );

--- a/test/features/btc_web/resumable_withdrawal_scope_test.dart
+++ b/test/features/btc_web/resumable_withdrawal_scope_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rbx_wallet/features/btc_web/models/btc_web_vbtc_token.dart';
+import 'package:rbx_wallet/features/nft/models/web_nft.dart';
+
+const _owner = 'ROwnerAddress0000000000000000000';
+const _holder = 'RHolderAddress000000000000000000';
+
+Map<String, dynamic> _request({
+  required String requestor,
+  String status = 'requested',
+  String hash = 'req-hash',
+}) {
+  return {
+    'id': 1,
+    'requestor_address': requestor,
+    'btc_address': 'bc1qdestination',
+    'amount': 0.0001,
+    'fee_rate': 2.0,
+    'status': status,
+    'request_transaction_hash': hash,
+    'btc_tx_hash': null,
+    'completion_tx_hash': null,
+  };
+}
+
+BtcWebVbtcToken _token(List<Map<String, dynamic>> requests) {
+  return BtcWebVbtcToken(
+    name: 'vBTC',
+    description: 'test token',
+    addresses: const {_owner: 0.0005, _holder: 0.0001},
+    address: _owner,
+    scIdentifier: 'sc:1',
+    ownerAddress: _owner,
+    imageUrl: '',
+    depositAddress: 'bc1pdeposit',
+    globalBalance: 0.0006,
+    createdAt: DateTime.utc(2026, 8, 2),
+    nft: WebNft.empty(),
+    version: 2,
+    withdrawalRequests: requests,
+  );
+}
+
+void main() {
+  group('resumable withdrawals are scoped to the requestor', () {
+    // The bug: a shared contract holds every holder's withdrawals in one list.
+    // Offering another holder's request to whoever is logged in makes the FROST
+    // leader address (taken from the stored RequestorAddress) disagree with the
+    // signature (made by the active wallet), so validators reject the ceremony
+    // and it hangs instead of failing.
+    test('a holder\'s outstanding request is not offered to the owner', () {
+      final token = _token([_request(requestor: _holder)]);
+
+      expect(token.resumableWithdrawalRequestsFor(_owner), isEmpty);
+      expect(token.hasResumableWithdrawalFor(_owner), isFalse);
+    });
+
+    test('the holder is still offered their own request', () {
+      final token = _token([_request(requestor: _holder)]);
+
+      final mine = token.resumableWithdrawalRequestsFor(_holder);
+      expect(mine, hasLength(1));
+      expect(mine.first['requestor_address'], _holder);
+      expect(token.hasResumableWithdrawalFor(_holder), isTrue);
+    });
+
+    test('each party sees only their own when both have one outstanding', () {
+      final token = _token([
+        _request(requestor: _owner, hash: 'owner-req'),
+        _request(requestor: _holder, hash: 'holder-req'),
+      ]);
+
+      expect(
+        token.resumableWithdrawalRequestsFor(_owner).single['request_transaction_hash'],
+        'owner-req',
+      );
+      expect(
+        token.resumableWithdrawalRequestsFor(_holder).single['request_transaction_hash'],
+        'holder-req',
+      );
+    });
+
+    test('a settled request is not resumable even for its own requestor', () {
+      final token = _token([_request(requestor: _holder, status: 'completed')]);
+
+      expect(token.resumableWithdrawalRequestsFor(_holder), isEmpty);
+    });
+
+    test('pending_btc stays resumable for its requestor', () {
+      // FROST has signed but the completion is unrecorded — precisely the state
+      // the requestor needs to come back and finish.
+      final token = _token([_request(requestor: _holder, status: 'pending_btc')]);
+
+      expect(token.hasResumableWithdrawalFor(_holder), isTrue);
+      expect(token.hasResumableWithdrawalFor(_owner), isFalse);
+    });
+
+    test('a locked session offers nothing rather than someone else\'s request', () {
+      final token = _token([_request(requestor: _holder)]);
+
+      expect(token.resumableWithdrawalRequestsFor(null), isEmpty);
+      expect(token.resumableWithdrawalRequestsFor(''), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Found during live end-to-end testing: switching accounts in the web wallet still showed a pending withdrawal that belonged to a **different** holder, blocking the owner from starting their own.

## The bug

A vBTC contract is shared, so every holder's withdrawals arrive in one list. Two places treated that list as if it were the current wallet's:

- `btc_web_vbtc_token.dart:56` — `resumableWithdrawalRequests` filtered by **status only**, no requestor filter
- `web_btc_tokenized_action_buttons.dart:256` — took `pending.first` and paired it with `myAddress`
- `web_tokenized_btc_detail_screen.dart:239` — made **every** holder's row tappable

## Why it is worse than a display bug

Acting on someone else's request doesn't fail cleanly — it hangs:

1. Wallet sends the other holder's `requestHash`, signs the leader auth with the **active** wallet
2. `ExecuteCompleteWithdrawalRaw` verifies that signature against the active wallet — **passes**
3. `VBTCService.cs:857` sets `coordinatorAddress = withdrawalRequest.RequestorAddress` → the **original** requestor
4. The ceremony broadcasts `LeaderAddress = original requestor` with the **active wallet's** signature
5. Each validator recomputes `{session}.{requestor}.{ts}` and the signature doesn't match → **rejected**

Every validator refuses, so the ceremony never starts and nothing returns. The caller waits out the full timeout with no error explaining why.

## The fix

`resumableWithdrawalRequestsFor(address)` **replaces** the unscoped getter rather than sitting alongside it, so the leaky version isn't left available to the next caller. A null or empty address returns nothing — with no wallet to compare against there is no request this session can safely finish. The detail screen gates both the tap and the cancel affordance on `isMine`.

## Desktop

Not scopeable the same way. `hasPendingWithdrawal` reads the contract's `ActiveWithdrawal*` fields — a single slot shared by all holders — and `GetContractList` carries no requestor, so there is nothing to compare against. The prompt no longer claims the withdrawal belongs to this account and states who can actually complete it. A comment records why it can't be fixed properly client-side.

**Follow-up for the node:** either expose the requestor on `GetContractList`, or make `ActiveWithdrawal*` per-user rather than a contract-global slot. Until then desktop can only warn.

## Verification

`fvm flutter analyze` — 0 errors, 0 warnings (351 info lints, unchanged from `main`). `fvm flutter test test/features` — all passing, 6 new.

Mutation-tested rather than assumed: removing the `requestor_address` filter fails **3 of the 6** new tests — precisely the cross-account isolation ones. The other 3 assert that legitimate resumes still work, and correctly stay green.

## Scope

This is confirmed to fix the account-switching problem. It is **not** confirmed to be the root cause of every stuck non-owner withdrawal — a requestor completing their *own* request has matching addresses and shouldn't hit this path. The plausible link is that one wrong-account attempt poisons the request via the validators' FIND-028 dedup tracker, which then blocks the legitimate requestor. That remains a hypothesis pending node logs.

Related data point: of 13 withdrawal requests network-wide, **all 4 stuck ones are non-owner requests** and all 7 owner requests completed. Two have been stuck since 2026-05-29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgVHBhKqU2XzPyJUQQPB8N