### PR TITLE
chore(release): 6.2.1

### DIFF
--- a/lib/core/app_constants.dart
+++ b/lib/core/app_constants.dart
@@ -3,7 +3,7 @@
 import 'package:rbx_wallet/core/env.dart';
 import 'package:flutter/foundation.dart';
 
-const APP_V = "6.2.0";
+const APP_V = "6.2.1";
 final APP_VERSION =
     "${Env.isDevnet ? 'Devnet' : Env.isTestNet ? 'Testnet' : 'Mainnet'} $APP_V";
 const APP_VERSION_NICKNAME = "Switchblade";

--- a/web/index.html
+++ b/web/index.html
@@ -89,7 +89,7 @@
       }
       scriptLoaded = true;
       var scriptTag = document.createElement("script");
-      scriptTag.src = "main.dart.js?version=6.2.0";
+      scriptTag.src = "main.dart.js?version=6.2.1";
       scriptTag.type = "application/javascript";
       document.body.append(scriptTag);
     }


### PR DESCRIPTION
Version bump for the withdrawal-scoping fix in #30.

| File | From | To |
|---|---|---|
| `lib/core/app_constants.dart` (`APP_V`) | 6.2.0 | **6.2.1** |
| `web/index.html` (`main.dart.js?version=`) | 6.2.0 | **6.2.1** |

Both were already in sync at 6.2.0, so they move together — a mismatch would leave the browser running cached Flutter output while the app reported the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgVHBhKqU2XzPyJUQQPB8N