### PR TITLE
fix(vbtc-v2-web): explain an in-progress withdrawal instead of failing at it

### DIFF
--- a/lib/core/app_constants.dart
+++ b/lib/core/app_constants.dart
@@ -3,7 +3,7 @@
 import 'package:rbx_wallet/core/env.dart';
 import 'package:flutter/foundation.dart';
 
-const APP_V = "6.2.1";
+const APP_V = "6.2.2";
 final APP_VERSION =
     "${Env.isDevnet ? 'Devnet' : Env.isTestNet ? 'Testnet' : 'Mainnet'} $APP_V";
 const APP_VERSION_NICKNAME = "Switchblade";

--- a/lib/features/btc_web/components/web_v2_withdrawal_dialog.dart
+++ b/lib/features/btc_web/components/web_v2_withdrawal_dialog.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
 import '../../../app.dart';
+import '../services/withdrawal_in_progress_notice.dart';
 import '../../../core/components/buttons.dart';
 import '../../../core/env.dart';
 import '../../../core/services/explorer_service.dart';
@@ -140,9 +141,21 @@ class _WebV2WithdrawalDialogState extends ConsumerState<WebV2WithdrawalDialog> {
     if (!mounted) return;
 
     if (result['success'] != true || result['hash'] == null) {
+      final message = result['message'] as String?;
+
+      // Not a failure — the contract simply has a withdrawal underway, and the
+      // holders share one Bitcoin deposit address so they run one at a time.
+      // Close out and explain it rather than leaving a red error on screen
+      // carrying the node's raw "verification failed" wording.
+      if (isWithdrawalAlreadyInProgress(message)) {
+        Navigator.of(context).pop();
+        await showWithdrawalInProgressNotice();
+        return;
+      }
+
       setState(() {
         _step = _DialogStep.failure;
-        _errorMessage = result['message'] ?? "Failed to broadcast withdrawal request.";
+        _errorMessage = message ?? "Failed to broadcast withdrawal request.";
       });
       return;
     }

--- a/lib/features/btc_web/services/withdrawal_in_progress_notice.dart
+++ b/lib/features/btc_web/services/withdrawal_in_progress_notice.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/dialogs.dart';
+
+/// The node refuses a second withdrawal while one is outstanding on the same
+/// contract, and reports it as a verification failure:
+///
+///   "Transaction verification failed: A withdrawal is already in progress for
+///    contract <scUID>; try again once it completes."
+///
+/// Matched on the stable clause rather than the whole sentence, so a reworded
+/// prefix or a different contract id still resolves.
+bool isWithdrawalAlreadyInProgress(String? message) {
+  if (message == null) return false;
+  return message.toLowerCase().contains('withdrawal is already in progress');
+}
+
+/// Explains the shared-contract withdrawal gate.
+///
+/// Presented as a state rather than a fault, because that is what it is: the
+/// holders of a vBTC contract share ONE Bitcoin deposit address, and a
+/// withdrawal spends its UTXOs. Two at once would select the same inputs and
+/// produce conflicting Bitcoin transactions, so the chain allows one at a time.
+/// Nothing is broken and nothing is lost.
+///
+/// The raw node message is deliberately not shown — it leads with
+/// "Transaction verification failed" and carries the full contract id, which
+/// reads like a defect and tells the user nothing they can act on.
+Future<void> showWithdrawalInProgressNotice() {
+  return InfoDialog.show(
+    title: "Withdrawal In Progress",
+    icon: Icons.hourglass_top,
+    closeText: "Got It",
+    body: "This token already has a withdrawal underway, so another can't start yet.\n\n"
+        "Everyone holding this token shares one Bitcoin deposit address. A withdrawal spends "
+        "from it, so they have to go one at a time — otherwise two withdrawals would try to "
+        "spend the same coins and neither would confirm.\n\n"
+        "Your funds are safe. Try again once the current withdrawal finishes. If it has stalled, "
+        "the token frees itself automatically about an hour after the request was made.",
+  );
+}

--- a/test/features/btc_web/withdrawal_in_progress_notice_test.dart
+++ b/test/features/btc_web/withdrawal_in_progress_notice_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rbx_wallet/features/btc_web/services/withdrawal_in_progress_notice.dart';
+
+void main() {
+  group('isWithdrawalAlreadyInProgress', () {
+    test('matches the node message verbatim', () {
+      const message =
+          'Transaction verification failed: A withdrawal is already in progress '
+          'for contract 9f30a25e581e44ffa447267820850700:1785606126; try again '
+          'once it completes.';
+
+      expect(isWithdrawalAlreadyInProgress(message), isTrue);
+    });
+
+    test('survives a reworded prefix and a different contract', () {
+      // Matched on the stable clause, so the node can change how it frames the
+      // rejection without this silently falling back to a red error screen.
+      expect(
+        isWithdrawalAlreadyInProgress(
+          'Rejected: a withdrawal is already in progress for contract abc:1',
+        ),
+        isTrue,
+      );
+    });
+
+    test('is case-insensitive', () {
+      expect(
+        isWithdrawalAlreadyInProgress('A WITHDRAWAL IS ALREADY IN PROGRESS'),
+        isTrue,
+      );
+    });
+
+    test('does not swallow unrelated failures', () {
+      // These must still reach the failure screen with their own message.
+      for (final message in const [
+        'Insufficient reachable validators. Have: 2, Need: 5',
+        'Withdrawal request already completed',
+        'Invalid start signature',
+        'Not enough balance',
+        '',
+      ]) {
+        expect(isWithdrawalAlreadyInProgress(message), isFalse, reason: message);
+      }
+    });
+
+    test('handles a missing message', () {
+      expect(isWithdrawalAlreadyInProgress(null), isFalse);
+    });
+  });
+}

--- a/web/index.html
+++ b/web/index.html
@@ -89,7 +89,7 @@
       }
       scriptLoaded = true;
       var scriptTag = document.createElement("script");
-      scriptTag.src = "main.dart.js?version=6.2.1";
+      scriptTag.src = "main.dart.js?version=6.2.2";
       scriptTag.type = "application/javascript";
       document.body.append(scriptTag);
     }


### PR DESCRIPTION
Found in live testing: withdrawing while the same token had a withdrawal underway surfaced the node's raw rejection on a red failure screen, and the actual reason was only visible in the network tab.

## Before

```
Transaction verification failed: A withdrawal is already in progress for
contract 9f30a25e581e44ffa447267820850700:1785606126; try again once it completes.
```

Leads with "verification failed", carries a contract id the user can't act on, and reads like a defect.

## Why it isn't a defect

The holders of a vBTC contract share **one Bitcoin deposit address**. A withdrawal spends its UTXOs, and `BitcoinTransactionService` selects them live and largest-first with no pinning — so two concurrent withdrawals would select the **same inputs** and produce conflicting Bitcoin transactions that cannot both confirm.

One at a time is the design. That's also why the gate is per *contract* rather than per *user* — the constraint is the shared UTXO set, not the ledger balances.

## After

An `InfoDialog` that says the token has a withdrawal underway, explains the shared deposit address in one line, states that funds are safe, and notes that a stalled request frees the token by itself after about an hour (`EXPIRY_BLOCKS = 360`). The withdrawal dialog closes instead of leaving a red error behind.

## Not swallowing real errors

Detection matches the stable clause (`withdrawal is already in progress`), not the whole sentence, so a reworded prefix or a different contract still resolves rather than silently falling back to the red screen.

Tests pin both directions — the node message verbatim, a reworded variant, case-insensitivity, and that unrelated failures (**insufficient validators**, **invalid signature**, **already completed**, empty) still reach the failure screen with their own message rather than being replaced by a reassuring dialog.

## Also

Bumps to **6.2.2** (`APP_V` + `main.dart.js?version=`, in lockstep) so the cache-bust ships with the change.

## Verification

`fvm flutter analyze` — 0 errors, 0 warnings (351 info lints, unchanged from `main`). `fvm flutter test test/features` — all passing, 5 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgVHBhKqU2XzPyJUQQPB8N