### PR TITLE
fix(vbtc-v2-web): let a holder start over once their request goes stale

### DIFF
--- a/lib/core/app_constants.dart
+++ b/lib/core/app_constants.dart
@@ -3,7 +3,7 @@
 import 'package:rbx_wallet/core/env.dart';
 import 'package:flutter/foundation.dart';
 
-const APP_V = "6.2.2";
+const APP_V = "6.2.3";
 final APP_VERSION =
     "${Env.isDevnet ? 'Devnet' : Env.isTestNet ? 'Testnet' : 'Mainnet'} $APP_V";
 const APP_VERSION_NICKNAME = "Switchblade";

--- a/lib/features/btc_web/components/web_btc_tokenized_action_buttons.dart
+++ b/lib/features/btc_web/components/web_btc_tokenized_action_buttons.dart
@@ -256,7 +256,7 @@ class WebTokenizedBtcActionButtons extends BaseComponent {
             // another holder's makes the FROST leader address and the
             // signature disagree, which validators reject — and the ceremony
             // then hangs rather than failing.
-            final pending = token.resumableWithdrawalRequestsFor(myAddress);
+            final pending = token.liveResumableWithdrawalRequestsFor(myAddress);
             if (pending.isNotEmpty) {
               final requestHash = pending.first['request_transaction_hash'] as String?;
               if (requestHash != null) {

--- a/lib/features/btc_web/models/btc_web_vbtc_token.dart
+++ b/lib/features/btc_web/models/btc_web_vbtc_token.dart
@@ -27,6 +27,31 @@ bool withdrawalIsResumable(Map<String, dynamic> withdrawalRequest) {
   return kResumableWithdrawalStatuses.contains(status.trim().toLowerCase());
 }
 
+/// How long before the chain stops treating a request as the contract's active
+/// one (VBTCWithdrawalRequest.EXPIRY_BLOCKS = 360, at ~12s blocks ≈ 72 min).
+///
+/// Judged from `created_at` because the explorer's withdrawal rows carry no
+/// block height. Deliberately longer than the real window: being late only
+/// means a user waits a little before starting fresh, whereas being early
+/// would stop them resuming a request the chain still considers live.
+const kWithdrawalStaleAfter = Duration(minutes: 90);
+
+/// True once the chain no longer treats this request as the contract's active
+/// one, so the next request simply overwrites it.
+///
+/// Such a request must not capture the withdraw button. It is not necessarily
+/// dead — nothing stops a completion — but the user has to be able to start a
+/// new withdrawal instead of being routed forever into resuming one the chain
+/// has already moved past.
+bool withdrawalIsStale(Map<String, dynamic> withdrawalRequest, {DateTime? now}) {
+  final created = withdrawalRequest['created_at'];
+  if (created is! String) return false;
+  final at = DateTime.tryParse(created);
+  if (at == null) return false;
+  final reference = now ?? DateTime.now().toUtc();
+  return reference.difference(at.toUtc()) > kWithdrawalStaleAfter;
+}
+
 @freezed
 class BtcWebVbtcToken with _$BtcWebVbtcToken {
   const BtcWebVbtcToken._();
@@ -72,6 +97,17 @@ class BtcWebVbtcToken with _$BtcWebVbtcToken {
         .where((w) => w['requestor_address'] == address)
         .toList();
   }
+
+  /// This wallet's outstanding withdrawals that the chain still treats as the
+  /// contract's active one, so resuming is the only way forward.
+  ///
+  /// Once a request goes stale the next one overwrites it, so it must not keep
+  /// capturing the withdraw button — otherwise a request that will not finish
+  /// leaves the holder unable to start another.
+  List<Map<String, dynamic>> liveResumableWithdrawalRequestsFor(String? address, {DateTime? now}) =>
+      resumableWithdrawalRequestsFor(address)
+          .where((w) => !withdrawalIsStale(w, now: now))
+          .toList();
 
   /// True when `address` has a withdrawal of its own still to finish.
   bool hasResumableWithdrawalFor(String? address) =>

--- a/test/features/btc_web/resumable_withdrawal_scope_test.dart
+++ b/test/features/btc_web/resumable_withdrawal_scope_test.dart
@@ -102,4 +102,48 @@ void main() {
       expect(token.resumableWithdrawalRequestsFor(''), isEmpty);
     });
   });
+
+  group('a stale request stops capturing the withdraw button', () {
+    // The chain stops treating a request as the contract's active one after
+    // EXPIRY_BLOCKS (360, ~72 min) and lets the next request overwrite it. Until
+    // then resuming is the only way forward; after it, forcing resume traps the
+    // holder on a request that may never finish.
+    Map<String, dynamic> aged(Duration age) => {
+          ..._request(requestor: _holder),
+          'created_at': DateTime.utc(2026, 8, 2, 12, 0)
+              .subtract(age)
+              .toIso8601String()
+              .replaceFirst('.000', ''),
+        };
+    final now = DateTime.utc(2026, 8, 2, 12, 0);
+
+    test('a fresh request is still resumed', () {
+      final token = _token([aged(const Duration(minutes: 5))]);
+
+      expect(token.liveResumableWithdrawalRequestsFor(_holder, now: now), hasLength(1));
+    });
+
+    test('a request past the window no longer captures the button', () {
+      final token = _token([aged(const Duration(hours: 8))]);
+
+      expect(token.liveResumableWithdrawalRequestsFor(_holder, now: now), isEmpty);
+      // Still listed, so it is not hidden — only no longer forced.
+      expect(token.resumableWithdrawalRequestsFor(_holder), hasLength(1));
+    });
+
+    test('the boundary errs toward keeping it resumable', () {
+      // 72 min is the real chain window; the client waits longer so it can
+      // never refuse to resume a request the chain still considers live.
+      final token = _token([aged(const Duration(minutes: 75))]);
+
+      expect(token.liveResumableWithdrawalRequestsFor(_holder, now: now), hasLength(1));
+    });
+
+    test('a missing or unparseable created_at is treated as live', () {
+      for (final value in [null, 'not-a-date', 42]) {
+        final row = {..._request(requestor: _holder), 'created_at': value};
+        expect(withdrawalIsStale(row, now: now), isFalse, reason: '$value');
+      }
+    });
+  });
 }

--- a/web/index.html
+++ b/web/index.html
@@ -89,7 +89,7 @@
       }
       scriptLoaded = true;
       var scriptTag = document.createElement("script");
-      scriptTag.src = "main.dart.js?version=6.2.2";
+      scriptTag.src = "main.dart.js?version=6.2.3";
       scriptTag.type = "application/javascript";
       document.body.append(scriptTag);
     }


### PR DESCRIPTION
Found in live testing: a fractional holder's stuck withdrawal left them unable to start a new one — the withdraw button routed to resume every time, and resume hangs.

## The problem

The withdraw button short-circuits to resume whenever the wallet has an outstanding request, and resume was its only option. So a request that won't complete **captures the button permanently** — the holder can't finish it and can't start another, on a token whose funds are untouched and fully spendable.

## The chain is more forgiving than the wallet

After `EXPIRY_BLOCKS` (360, ~72 min) the node stops treating a request as the contract's active one and **lets the next request overwrite it** — that's the documented recovery path for a stuck request, and it's exactly how the owner's withdrawal got unblocked tonight.

The wallet was enforcing a stricter rule than the protocol it front-ends.

## The change

- **Live request** → resume still wins. The chain refuses a second request while one is active, so finishing really is the only way forward.
- **Stale request** → the button starts a new withdrawal, matching what the chain will do with the old one anyway.

Stale requests **stay listed** on the detail screen. This hides nothing; it only stops a dead request holding the button hostage.

## On the threshold

Judged from `created_at`, since the explorer's withdrawal rows carry no block height (verified against the live API). Set to **90 minutes against a real window of ~72** — deliberately late.

Erring late costs a short wait. Erring early would refuse to resume a request the chain still considers live, which is the worse failure and would reintroduce the stuck-withdrawal problem from the other direction. An absent or unparseable timestamp counts as live for the same reason.

## Verification

`fvm flutter analyze` — 0 errors, 0 warnings (351 info lints, unchanged). `fvm flutter test test/features` — all passing.

Mutation-tested: removing the staleness filter fails the new tests. Boundary case (75 min) is pinned to stay resumable, so the "err late" property is enforced rather than assumed.

Also bumps to **6.2.3** (`APP_V` + cache-bust in lockstep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgVHBhKqU2XzPyJUQQPB8N