### PR TITLE
fix(vbtc-v2-web): don't let a dead beacon block a transfer with no media

### DIFF
--- a/lib/core/app_constants.dart
+++ b/lib/core/app_constants.dart
@@ -3,7 +3,7 @@
 import 'package:rbx_wallet/core/env.dart';
 import 'package:flutter/foundation.dart';
 
-const APP_V = "6.2.3";
+const APP_V = "6.2.4";
 final APP_VERSION =
     "${Env.isDevnet ? 'Devnet' : Env.isTestNet ? 'Testnet' : 'Mainnet'} $APP_V";
 const APP_VERSION_NICKNAME = "Switchblade";

--- a/lib/features/btc_web/services/vbtc_media_detection.dart
+++ b/lib/features/btc_web/services/vbtc_media_detection.dart
@@ -1,0 +1,33 @@
+import '../../nft/models/web_nft.dart';
+
+/// Asset names the mint stamps on a vBTC contract that carries no real media.
+///
+/// A default-asset vBTC v2 contract registers a placeholder so the token has
+/// something to render, but no file is ever written to disk or shipped through
+/// a beacon. The node reaches the same conclusion from the state trei's
+/// MD5List, which lists only `defaultvBTC*` entries for these contracts
+/// (MD5Utility.HasMedia).
+const _kNoMediaAssetNames = {'vbtc_v2_token'};
+
+/// Prefix of the built-in placeholder images (`defaultvBTC.png`,
+/// `defaultvBTC_V2.png`). Matched as a prefix because both spellings exist.
+const _kDefaultAssetPrefix = 'defaultvbtc';
+
+/// True when this contract demonstrably has no media file to transfer.
+///
+/// Deliberately conservative, because the two mistakes are not equal. Deciding
+/// "no media" for a contract that HAS a file would skip shipping it and leave
+/// the recipient unable to fetch it. Deciding "has media" for one that does not
+/// merely keeps today's behaviour. So this returns true only on positive
+/// evidence — a zero-size asset AND a recognised placeholder name — and false
+/// whenever anything is unclear.
+bool vbtcContractHasNoMedia(WebNft? nft) {
+  if (nft == null) return false;
+
+  if (nft.primaryAssetSize != 0) return false;
+
+  final name = nft.primaryAssetName.trim().toLowerCase();
+  if (name.isEmpty) return false;
+
+  return _kNoMediaAssetNames.contains(name) || name.startsWith(_kDefaultAssetPrefix);
+}

--- a/lib/features/token/providers/web_token_actions_manager.dart
+++ b/lib/features/token/providers/web_token_actions_manager.dart
@@ -16,6 +16,7 @@ import '../../../utils/toast.dart';
 import '../../../utils/validation.dart';
 import '../../btc_web/models/btc_web_vbtc_token.dart';
 import '../../btc_web/services/frost_resume_guard.dart';
+import '../../btc_web/services/vbtc_media_detection.dart';
 import '../../btc_web/services/pending_frost_signing_job_service.dart';
 import '../../btc_web/services/pending_withdrawal_completion_service.dart';
 import '../../global_loader/global_loading_provider.dart';
@@ -296,6 +297,21 @@ class WebTokenActionsManager {
     );
   }
 
+  /// Whether this vBTC contract has no media file to ship through a beacon.
+  ///
+  /// Returns false if the lookup fails: without positive evidence the transfer
+  /// keeps requiring a beacon rather than risking a token whose file never
+  /// reaches the recipient.
+  Future<bool> _contractHasNoMedia(String scIdentifier) async {
+    try {
+      final token = await ExplorerService().getWebVbtcV2TokenDetail(scIdentifier);
+      return vbtcContractHasNoMedia(token.nft);
+    } catch (e) {
+      print("Could not determine media for $scIdentifier: $e");
+      return false;
+    }
+  }
+
   /// Signs a hash and sends the signature to a "send" endpoint.
   /// Common pattern for all V2 two-step operations.
   Future<bool?> transferVbtcOwnership({
@@ -321,11 +337,25 @@ class WebTokenActionsManager {
 
     ref.read(globalLoadingProvider.notifier).start();
 
-    final locator = await RawService().beaconUpload(scIdentifier, toAddress, beaconSig);
+    var locator = await RawService().beaconUpload(scIdentifier, toAddress, beaconSig);
     if (locator == null) {
-      ref.read(globalLoadingProvider.notifier).complete();
-      Toast.error("Beacon upload failed");
-      return false;
+      // A contract with no media has nothing to ship, so a dead beacon should
+      // not stop the transfer. The node reaches the same conclusion from the
+      // state trei and forces the "NA" locator itself; this stops the wallet
+      // aborting before the node is ever asked.
+      //
+      // Only checked once the upload has already failed, so the working path is
+      // untouched and this costs nothing when beacons are healthy.
+      if (await _contractHasNoMedia(scIdentifier)) {
+        locator = "NA";
+      } else {
+        ref.read(globalLoadingProvider.notifier).complete();
+        Toast.error(
+          "Beacon upload failed. This token has a media file that must be transferred with it, "
+          "so the transfer cannot continue until a beacon is reachable.",
+        );
+        return false;
+      }
     }
 
     // Step 2: Get transfer TX data

--- a/test/features/btc_web/vbtc_media_detection_test.dart
+++ b/test/features/btc_web/vbtc_media_detection_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rbx_wallet/features/btc_web/services/vbtc_media_detection.dart';
+import 'package:rbx_wallet/features/nft/models/web_nft.dart';
+
+WebNft _nft({required String assetName, required int assetSize}) {
+  return WebNft.empty().copyWith(
+    primaryAssetName: assetName,
+    primaryAssetSize: assetSize,
+  );
+}
+
+void main() {
+  group('vbtcContractHasNoMedia', () {
+    test('the default vBTC asset has no media', () {
+      // What the mint actually stamps: asset name vbtc_v2_token, FileSize 0.
+      expect(
+        vbtcContractHasNoMedia(_nft(assetName: 'vbtc_v2_token', assetSize: 0)),
+        isTrue,
+      );
+    });
+
+    test('both placeholder image spellings are recognised', () {
+      // The node emits defaultvBTC.png and defaultvBTC_V2.png; matching on the
+      // prefix covers both, which an equality check would not.
+      for (final name in ['defaultvBTC.png', 'defaultvBTC_V2.png']) {
+        expect(
+          vbtcContractHasNoMedia(_nft(assetName: name, assetSize: 0)),
+          isTrue,
+          reason: name,
+        );
+      }
+    });
+
+    test('matching is case-insensitive', () {
+      expect(
+        vbtcContractHasNoMedia(_nft(assetName: 'DEFAULTVBTC.PNG', assetSize: 0)),
+        isTrue,
+      );
+    });
+
+    test('a real asset has media', () {
+      expect(
+        vbtcContractHasNoMedia(_nft(assetName: 'artwork.png', assetSize: 51200)),
+        isFalse,
+      );
+    });
+
+    test('a non-zero size means media even under a placeholder name', () {
+      // Size wins. A file that exists must be shipped whatever it is called.
+      expect(
+        vbtcContractHasNoMedia(_nft(assetName: 'vbtc_v2_token', assetSize: 2048)),
+        isFalse,
+      );
+    });
+
+    test('an unrecognised name is treated as media even at size zero', () {
+      // Deciding "no media" wrongly strands the recipient's file, so anything
+      // unfamiliar keeps requiring a beacon.
+      expect(
+        vbtcContractHasNoMedia(_nft(assetName: 'mystery.bin', assetSize: 0)),
+        isFalse,
+      );
+    });
+
+    test('an empty or missing name is treated as media', () {
+      expect(vbtcContractHasNoMedia(_nft(assetName: '', assetSize: 0)), isFalse);
+      expect(vbtcContractHasNoMedia(_nft(assetName: '   ', assetSize: 0)), isFalse);
+    });
+
+    test('a null nft is treated as media', () {
+      expect(vbtcContractHasNoMedia(null), isFalse);
+    });
+  });
+}

--- a/web/index.html
+++ b/web/index.html
@@ -89,7 +89,7 @@
       }
       scriptLoaded = true;
       var scriptTag = document.createElement("script");
-      scriptTag.src = "main.dart.js?version=6.2.3";
+      scriptTag.src = "main.dart.js?version=6.2.4";
       scriptTag.type = "application/javascript";
       document.body.append(scriptTag);
     }


### PR DESCRIPTION
All five default network beacons are currently down, and the wallet called `beaconUpload` unconditionally — aborting the transfer if it failed. So vBTC tokens with **no media file** could not be transferred at all, despite having nothing to ship.

## The node already solved this; the wallet never asked

`GetVBTCOwnershipTransferData` forces the `"NA"` locator for contracts whose `MD5List` carries only the default placeholder. But that lives **past** the wallet's beacon gate:

```dart
final locator = await RawService().beaconUpload(...);
if (locator == null) {
  Toast.error("Beacon upload failed");
  return false;          // ← node never consulted
}
```

## The change

A failed upload is now only fatal when the contract genuinely has a file to ship. The media lookup runs **only after the upload has already failed**, so the healthy path is byte-for-byte unchanged and costs nothing.

## Conservative by design

The two mistakes aren't equal. Calling a media contract "no media" would skip shipping its file and strand the recipient. The reverse just keeps today's behaviour.

So it requires **positive evidence** — zero-size asset **and** a recognised placeholder name (`vbtc_v2_token`, or the `defaultvBTC` prefix which covers both `.png` and `_V2.png`) — and returns false whenever anything is unclear, **including when the lookup itself fails**.

The remaining fatal path now explains *why* a beacon is required instead of reporting a bare failure.

## Verification

`fvm flutter analyze` — 0 errors, 0 warnings (351 info, unchanged). `fvm flutter test test/features` — all passing, 8 new.

Mutation-tested: removing the zero-size guard fails the suite, so the conservative property is enforced rather than assumed.

Bumps to **6.2.4** (`APP_V` + cache-bust in lockstep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgVHBhKqU2XzPyJUQQPB8N