### PR TITLE
fix(vbtc-v2-web): treat a blank beacon locator as no locator

### DIFF
--- a/lib/core/app_constants.dart
+++ b/lib/core/app_constants.dart
@@ -3,7 +3,7 @@
 import 'package:rbx_wallet/core/env.dart';
 import 'package:flutter/foundation.dart';
 
-const APP_V = "6.2.4";
+const APP_V = "6.2.5";
 final APP_VERSION =
     "${Env.isDevnet ? 'Devnet' : Env.isTestNet ? 'Testnet' : 'Mainnet'} $APP_V";
 const APP_VERSION_NICKNAME = "Switchblade";

--- a/lib/features/token/providers/web_token_actions_manager.dart
+++ b/lib/features/token/providers/web_token_actions_manager.dart
@@ -338,6 +338,16 @@ class WebTokenActionsManager {
     ref.read(globalLoadingProvider.notifier).start();
 
     var locator = await RawService().beaconUpload(scIdentifier, toAddress, beaconSig);
+
+    // A blank locator is as unusable as a missing one, and worse in practice: it
+    // survives a null check and then collapses the transfer-data URL to an empty
+    // path segment, which the explorer route cannot match and answers 404. A
+    // no-media upload reports success with nothing to locate, so this is the
+    // normal result for exactly the contracts that need the fallback.
+    if (locator != null && locator.trim().isEmpty) {
+      locator = null;
+    }
+
     if (locator == null) {
       // A contract with no media has nothing to ship, so a dead beacon should
       // not stop the transfer. The node reaches the same conclusion from the

--- a/web/index.html
+++ b/web/index.html
@@ -89,7 +89,7 @@
       }
       scriptLoaded = true;
       var scriptTag = document.createElement("script");
-      scriptTag.src = "main.dart.js?version=6.2.4";
+      scriptTag.src = "main.dart.js?version=6.2.5";
       scriptTag.type = "application/javascript";
       document.body.append(scriptTag);
     }


### PR DESCRIPTION
Follow-on from #34. Jay got past the beacon error and immediately hit **"Ownership transfer failed: Error getting ownership transfer data."**

## Cause

The guard checked only for a **null** locator. A **blank** one passes that check and then collapses the URL to an empty path segment:

```
/btc/vbtc-v2/ownership-transfer/<sc>/<to>//
```

Django's `<path:locator>` route can't match an empty segment, so it 404s, and the wallet turns that into the generic error.

This is the *normal* result for exactly the contracts #34 was written for: a no-media beacon upload reports success because there was nothing to send, and hands back an empty locator with it.

## Verified against the live explorer

Contract `00ffacd4817946419202112a39c884ad:1785694242` (the one in Jay's screenshot):

| locator | result |
|---|---|
| `NA` | **200** ✅ |
| `16.147.210.151:23338:someuid123` | **200** ✅ |
| `abc123locator` | **200** ✅ |
| *(empty)* | **404** ❌ |

## The change

A blank locator is normalised to null, so it takes the same no-media fallback #34 added and is sent as `"NA"`.

`fvm flutter analyze` clean (2 pre-existing unused imports), `test/features` all passing. Bumps to **6.2.5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgVHBhKqU2XzPyJUQQPB8N